### PR TITLE
[WIP] Customizations based on the response

### DIFF
--- a/example/example/customizations.py
+++ b/example/example/customizations.py
@@ -1,0 +1,15 @@
+from typing import Type
+
+from urllib.request import Request
+
+from example.spiders.books_06 import AsimovFoundationBookPage, BookPage
+from scrapy_po.customizations import Customizations
+
+
+class ExampleCustomizations(Customizations):
+
+    def __call__(self, request: Request, response, spider, cls: Type) -> Type:
+        if response.url == "http://books.toscrape.com/catalogue/foundation-foundation-publication-order-1_375/index.html":
+            if cls == BookPage:
+                return AsimovFoundationBookPage
+        return cls

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -56,6 +56,8 @@ DOWNLOADER_MIDDLEWARES = {
    'scrapy_po.InjectPageObjectsMiddleware': 543,
 }
 
+PAGEOBJECTS_BINDINGS = 'example.customizations.ExampleCustomizations'
+
 # Enable or disable extensions
 # See https://docs.scrapy.org/en/latest/topics/extensions.html
 #EXTENSIONS = {

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -56,7 +56,7 @@ DOWNLOADER_MIDDLEWARES = {
    'scrapy_po.InjectPageObjectsMiddleware': 543,
 }
 
-PAGEOBJECTS_BINDINGS = 'example.customizations.ExampleCustomizations'
+PAGEOBJECTS_CUSTOMIZATONS = 'example.customizations.ExampleCustomizations'
 
 # Enable or disable extensions
 # See https://docs.scrapy.org/en/latest/topics/extensions.html

--- a/example/example/spiders/books_06.py
+++ b/example/example/spiders/books_06.py
@@ -48,6 +48,17 @@ class BookPage(WebPage, ItemPage):
         }
 
 
+@attr.s(auto_attribs=True)
+class AsimovFoundationBookPage(BookPage):
+    """ Example of a customization just for the single URL
+    http://books.toscrape.com/catalogue/foundation-foundation-publication-order-1_375/index.html """
+    def to_item(self):
+        item = super().to_item()
+        item['name'] = 'Foundation'  # Fixing title
+        item['price'] = self.css(".price_color::text").get()  # Adding price
+        return item
+
+
 class BooksSpider(scrapy.Spider):
     name = 'books_06'
     start_urls = ['http://books.toscrape.com/']

--- a/scrapy_po/customizations.py
+++ b/scrapy_po/customizations.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+""" Customizations allows to choose the right PageObject based on the response """
 import abc
 from scrapy import Request, Spider
 from scrapy.http import Response

--- a/scrapy_po/customizations.py
+++ b/scrapy_po/customizations.py
@@ -1,0 +1,23 @@
+import abc
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from typing import Type, Mapping
+
+
+class Customizations:
+
+    def __init__(self, crawler, *args, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def __call__(self, request: Request, response: Response,
+                 spider: Spider, cls: Type) -> Type:
+        pass
+
+
+class IdentityCustomizations(Customizations):
+
+    def __call__(self, request: Request, response: Response,
+                 spider: Spider, cls: Type) -> Type:
+        return cls

--- a/scrapy_po/middleware.py
+++ b/scrapy_po/middleware.py
@@ -16,8 +16,8 @@ from .page_input_providers import providers
 
 class InjectPageObjectsMiddleware:
 
-    def __init__(self, bindings: Customizations):
-        self.bindings = bindings
+    def __init__(self, customizations: Customizations):
+        self.customizations = customizations
 
     """
     This downloader middleware instantiates all PageObject subclasses declared
@@ -35,7 +35,7 @@ class InjectPageObjectsMiddleware:
         callback = get_callback(request, spider)
         providers = build_providers(response)
         can_provide = can_provide_fn(providers)
-        bindings = partial(self.bindings.__call__, request, response, spider)
+        bindings = partial(self.customizations.__call__, request, response, spider)
         plan = andi.plan(callback, can_provide, providers.__contains__,
                          bindings)
 
@@ -60,7 +60,7 @@ class InjectPageObjectsMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):
-        bnd_cls_str = crawler.settings.get("PAGEOBJECTS_BINDINGS")
+        bnd_cls_str = crawler.settings.get("PAGEOBJECTS_CUSTOMIZATIONS")
         bnd_cls = (load_object(bnd_cls_str) if bnd_cls_str else IdentityCustomizations)
         bindings = bnd_cls(crawler, *args, **kwargs)
         return cls(bindings)

--- a/scrapy_po/middleware.py
+++ b/scrapy_po/middleware.py
@@ -60,10 +60,10 @@ class InjectPageObjectsMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):
-        bnd_cls_str = crawler.settings.get("PAGEOBJECTS_CUSTOMIZATIONS")
-        bnd_cls = (load_object(bnd_cls_str) if bnd_cls_str else IdentityCustomizations)
-        bindings = bnd_cls(crawler, *args, **kwargs)
-        return cls(bindings)
+        cstm_cls_str = crawler.settings.get("PAGEOBJECTS_CUSTOMIZATIONS")
+        cstm_cls = (load_object(cstm_cls_str) if cstm_cls_str else IdentityCustomizations)
+        customizations = cstm_cls(crawler, *args, **kwargs)
+        return cls(customizations)
 
 
 def build_providers(response) -> Dict[type, Callable]:


### PR DESCRIPTION
Injected PageObjects can now be modified based on the response. This
allows to create specialized PO for each domain or based in the content
(i.e. use a particular pagination PO if a particular type of pagination
is detected in the content).

The developed mechanism is very low level at the moment. Some more helper helpers to simply configuration would be handy. For example to configure PO per domain, so that they can be configured with dicts like:
```py
{'domain.x.y': {
    BookPage: DomainXYBookPage, 
    BookPagination: DomainXYBookPagination
    }, 
 'domain.z.w': ...
}
```

Note that the base branch is not master, but `andi_recursive_injection`

@kmike what do you think?