### PR TITLE
Documentation follow-up

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -44,7 +44,7 @@ current scrapy-poet behavior.
 .. warning::
 
     Currently, scrapy-poet is only able to inject ``Response`` and
-    ``DummyResponse`` instances as *provider* dependencies.
+    :class:`~.DummyResponse` instances as *provider* dependencies.
 
 Ignoring requests
 =================
@@ -54,7 +54,7 @@ using a third-party API such as Auto Extract or querying a database.
 
 In cases like that, it makes no sense to send the request to Scrapy's downloader
 as it will only waste network resources. But there's an alternative to avoid
-making such requests, you could use ``DummyRequests`` type to annotate
+making such requests, you could use :class:`~.DummyResponse` type to annotate
 your response arguments.
 
 That could be done in the spider's parser method:
@@ -70,11 +70,11 @@ to not download scrapy Response as usual.
 
 This type annotation is already applied when you use the :func:`~.callback_for`
 helper: the callback which is created by ``callback_for`` doesn't use Response,
-it just calls page object's to_item method.
+it just calls page object's ``to_item`` method.
 
 If neither spider callback nor any of the input providers are using
-``Response``, InjectionMiddleware skips the download, returning a
-``DummyResponse`` instead. For example:
+``Response``, :class:`~.InjectionMiddleware` skips the download, returning a
+:class:`~.DummyResponse` instead. For example:
 
 .. code-block:: python
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -7,9 +7,10 @@ Advanced Usage
 Creating providers
 ==================
 
-Providers are responsible for building dependencies needed by Injectors. A very
-good example would be the ``ResponseDataProvider``, which builds and provides a
-``ResponseData`` instance for Injectors that need it, like the ``ItemWebPage``.
+Providers are responsible for building dependencies needed by Injectable
+objects. A good example would be the ``ResponseDataProvider``,
+which builds and provides a ``ResponseData`` instance for Injectables
+that need it, like the ``ItemWebPage``.
 
 .. code-block:: python
 
@@ -42,9 +43,8 @@ current scrapy-poet behavior.
 
 .. warning::
 
-    Currently, scrapy-poet is only able to inject ``Response`` instances as
-    provider dependencies. We should be able to overcome this limitation in the
-    future.
+    Currently, scrapy-poet is only able to inject ``Response`` and
+    ``DummyResponse`` instances as *provider* dependencies.
 
 Ignoring requests
 =================
@@ -64,13 +64,16 @@ That could be done in the spider's parser method:
     def parser(self, response: DummyRequest, page: MyPageObject):
         pass
 
-Spiders that annotate its first argument as ``DummyResponse`` are signaling that
-they're not going to make use of it, so it should be safe to skip it from our
-downloader middleware. This type annotation is already applied when you use the
-``callback_for`` helper.
+Spider method that has its first argument annotated as :class:`~.DummyResponse`
+is signaling that it is not going to use the response, so it should be safe
+to not download scrapy Response as usual.
 
-If neither spider callback or any of the input providers are going to make use
-of a ``Response``, our Injection Middleware skips download returning a
+This type annotation is already applied when you use the :func:`~.callback_for`
+helper: the callback which is created by ``callback_for`` doesn't use Response,
+it just calls page object's to_item method.
+
+If neither spider callback nor any of the input providers are using
+``Response``, InjectionMiddleware skips the download, returning a
 ``DummyResponse`` instead. For example:
 
 .. code-block:: python
@@ -120,9 +123,8 @@ of a ``Response``, our Injection Middleware skips download returning a
             # not MyPageObject seem like to be making use of its response
             yield page.to_item()
 
-Although, if the spider callback is not going to use the ``Response``, but the
-Page Object makes use of it, the request is not going to be ignored and will be
-processed, for example:
+Although, if the spider callback is not using ``Response``, but the
+Page Object uses it, the request is not ignored, for example:
 
 .. code-block:: python
 
@@ -174,8 +176,10 @@ processed, for example:
 .. note::
 
     The code above is just for example purposes. If you need to use ``Response``
-    instances in your code, make use of ``ItemWebPage`` as it makes use of the
-    built-ins ``ResponseData`` and ``ResponseDataProvider``.
+    instances in your Page Objects, use built-in ``ItemWebPage`` - it has
+    ``response`` attribute with ``ResponseData``; no additional configuration
+    is needed, as there is ``ResponseDataProvider`` enabled in scrapy-poet
+    by default.
 
 Requests concurrency
 --------------------
@@ -184,32 +188,22 @@ DummyRequests are meant to skip downloads, so it makes sense not checking for
 concurrent requests, delays, or auto throttle settings since we won't be making
 any download at all.
 
-By default, if your parser or its page inputs need a regular Request, it will
-be downloaded through Scrapy and all settings related to it are going to be
+By default, if your parser or its page inputs need a regular Request,
+this request is downloaded through Scrapy, and all the settings and limits are
 respected, for example:
 
 - ``CONCURRENT_REQUESTS``
 - ``CONCURRENT_REQUESTS_PER_DOMAIN``
 - ``CONCURRENT_REQUESTS_PER_IP``
 - ``RANDOMIZE_DOWNLOAD_DELAY``
-- ``DownloaderAwarePriorityQueue``
-- ``AutoThrottle``
+- all AutoThrottle settings
+- ``DownloaderAwarePriorityQueue`` logic
 
 But be aware when using third-party libraries to acquire content for a page
 object. If you make an HTTP request in a provider using some third-party async
 library (aiohttp, treq, etc.), ``CONCURRENT_REQUESTS`` option will be respected,
-but not the other settings.
+but not the others.
 
 To have other settings respected, in addition to ``CONCURRENT_REQUESTS``, you'd
 need to use ``crawler.engine.download`` or something like that. Alternatively,
 you could implement those limits in the library itself.
-
-In the future, it should be also possible to make use of
-``DownloaderAwarePriorityQueue`` in such cases, but it will require a
-refactoring on Scrapy (this is a separate task).
-
-In the following versions of scrapy-poet, we're planning to include a new Page
-Object type responsible for receiving spider-related settings. That could be
-the whole Scrapy settings or just a sub-set of it. It's yet to be defined and
-implemented, but that will make it easier to enforce those Scrapy settings on
-providers.

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -21,7 +21,7 @@ Utils
    :members:
    :no-special-members:
 
-.. automethod:: scrapy_poet.utils.callback_for
+.. autofunction:: scrapy_poet.callback_for
 
 .. toctree::
    :hidden:

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -2,6 +2,15 @@
 API Reference
 =============
 
+Utils
+=====
+
+.. autofunction:: scrapy_poet.callback_for
+
+.. autoclass:: scrapy_poet.utils.DummyResponse
+   :members:
+   :no-special-members:
+
 Injection Middleware
 ====================
 
@@ -14,14 +23,6 @@ Page Input Providers
 .. automodule:: scrapy_poet.page_input_providers
    :members:
 
-Utils
-=====
-
-.. autoclass:: scrapy_poet.utils.DummyResponse
-   :members:
-   :no-special-members:
-
-.. autofunction:: scrapy_poet.callback_for
-
 .. toctree::
    :hidden:
+

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -12,10 +12,10 @@ a website that lists books from famous authors.
 
 This tutorial will walk you through these tasks:
 
-1. Writing a :ref:`spider <scrapy:topics-spiders>` to crawl a site and extract data
-3. Separating extraction logic from the spider
-3. Configuring Scrapy project to use scrapy-poet
-4. Changing spider to make use of our extraction logic
+#. Writing a :ref:`spider <scrapy:topics-spiders>` to crawl a site and extract data
+#. Separating extraction logic from the spider
+#. Configuring Scrapy project to use scrapy-poet
+#. Changing spider to make use of our extraction logic
 
 If you're not already familiar with Scrapy, and want to learn it quickly,
 the `Scrapy Tutorial`_ is a good resource.
@@ -139,6 +139,9 @@ a BookPage instance is created and passed to the callback.
 The full spider code would be looking like this:
 
 .. code-block:: python
+
+    import scrapy
+
 
     class BooksSpider(scrapy.Spider):
         """Crawl and extract books data"""

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -13,8 +13,8 @@ a website that lists books from famous authors.
 This tutorial will walk you through these tasks:
 
 1. Writing a :ref:`spider <scrapy:topics-spiders>` to crawl a site and extract data
-2. Configuring Scrapy project to include Injection Middleware
-3. Separating extraction logic from spider
+3. Separating extraction logic from the spider
+3. Configuring Scrapy project to use scrapy-poet
 4. Changing spider to make use of our extraction logic
 
 If you're not already familiar with Scrapy, and want to learn it quickly,
@@ -24,9 +24,12 @@ Creating a spider
 =================
 
 Create a new Scrapy project and add a new spider to it. This spider will be
-called ``books`` and it will crawl and extract data from our target website.
+called ``books`` and it will crawl and extract data from a target website.
 
 .. code-block:: python
+
+    import scrapy
+
 
     class BooksSpider(scrapy.Spider):
         """Crawl and extract books data"""
@@ -35,7 +38,7 @@ called ``books`` and it will crawl and extract data from our target website.
         start_urls = ['http://books.toscrape.com/']
 
         def parse(self, response):
-            """Discovers book links and follows them"""
+            """Discover book links and follow them"""
             links = response.css('.image_container a')
             yield from response.follow_all(links, self.parse_book)
 
@@ -46,24 +49,11 @@ called ``books`` and it will crawl and extract data from our target website.
                 'name': response.css("title::text").get(),
             }
 
-Configuring the project
-=======================
-
-We need to enable our custom downloader middleware in ``settings.py``.
-It's a fundamental part of scrapy-poet as it makes dependency injection possible
-(among other things).
-
-.. code-block:: python
-
-    DOWNLOADER_MIDDLEWARES = {
-       'scrapy_poet.InjectionMiddleware': 543,
-    }
-
 Separating extraction logic
 ===========================
 
-Let's create our first Page Object abstraction by moving extraction logic
-outside our spider file.
+Let's create our first Page Object by moving extraction logic
+out of the spider class.
 
 .. code-block:: python
 
@@ -83,7 +73,13 @@ outside our spider file.
             }
 
 Now we have a ``BookPage`` class that implements the ``to_item`` method.
-We could go even further and extract a property from the ``to_item`` method.
+This class contains all logic necessary for extracting an item from
+an individual book page like
+http://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html,
+and nothing else.
+
+If we want, we can organize code in a different way, and e.g.
+extract a property from the ``to_item`` method:
 
 .. code-block:: python
 
@@ -91,36 +87,56 @@ We could go even further and extract a property from the ``to_item`` method.
 
 
     class BookPage(ItemWebPage):
-        """Extracts data from a book page"""
+        """Individual book page on books.toscrape.com website"""
 
         @property
         def title(self):
-            """Extracts title from book page"""
+            """Book page title"""
             return self.css("title::text").get()
 
         def to_item(self):
-            """Converts page into an item"""
             return {
                 'url': self.url,
                 'name': self.title,
             }
 
-Changing spider
-===============
+Configuring the project
+=======================
 
-The next step is to change our ``parse_book`` method in order to consume our
-newly created Page Object class.
+To use scrapy-poet, enable its downloader middleware in ``settings.py``:
 
 .. code-block:: python
 
-    def parse_book(self, response, book_page: BookPage):
-        """Extract data from book pages"""
-        yield book_page.to_item()
+    DOWNLOADER_MIDDLEWARES = {
+        'scrapy_poet.InjectionMiddleware': 543,
+    }
 
-The parser method now receives a type annotated argument called ``book_page``.
-Our Injection Middleware will detect it and provide the required dependencies.
 
-The spider should be looking like this:
+BookPage class we created previously can be used without scrapy-poet,
+and even without Scrapy (note that imports were from ``web_poet`` so far).
+
+``scrapy-poet`` makes it easy to use ``web-poet`` Page Objects
+(such as BookPage) in Scrapy spiders.
+
+Changing spider
+===============
+
+To use the newly created BookPage class in the spider, change
+the ``parse_book`` method as follows:
+
+.. code-block:: python
+
+    class BooksSpider(scrapy.Spider):
+        # ...
+        def parse_book(self, response, book_page: BookPage):
+            """Extract data from book pages"""
+            yield book_page.to_item()
+
+``parse_book`` method now has a type annotated argument
+called ``book_page``. scrapy-poet detects this and makes sure
+a BookPage instance is created and passed to the callback.
+
+The full spider code would be looking like this:
 
 .. code-block:: python
 
@@ -131,7 +147,7 @@ The spider should be looking like this:
         start_urls = ['http://books.toscrape.com/']
 
         def parse(self, response):
-            """Discovers book links and follows them"""
+            """Discover book links and follow them"""
             links = response.css('.image_container a')
             yield from response.follow_all(links, self.parse_book)
 
@@ -139,12 +155,14 @@ The spider should be looking like this:
             """Extract data from book pages"""
             yield book_page.to_item()
 
-You might have noticed that our parser method is quite simples and it's just
-returning the result of the ``to_item`` method call. We could make use of the
-``callback_for`` helper to reduce boilerplate.
+
+You might have noticed that ``parse_book`` is quite simple; it's just
+returning the result of the ``to_item`` method call. We could use
+:func:`~.callback_for` helper to reduce the boilerplate.
 
 .. code-block:: python
 
+    import scrapy
     from scrapy_poet import callback_for
 
 
@@ -160,38 +178,34 @@ returning the result of the ``to_item`` method call. We could make use of the
             links = response.css('.image_container a')
             yield from response.follow_all(links, self.parse_book)
 
+
 .. note::
 
-    You can also write something like ``Request(url, callback_for(BookPage))``,
-    without creating an attribute, but currently it won't work with Scrapy disk
-    queues.
+    You can also write something like
+    ``response.follow_all(links, callback_for(BookPage))``, without creating
+    an attribute, but currently it won't work with Scrapy disk queues.
 
 Final result
 ============
 
-At the end of our job, our spider should look like this:
+At the end of our job, the spider should look like this:
 
 .. code-block:: python
 
     import scrapy
-
-    from scrapy_poet import callback_for
     from web_poet.pages import ItemWebPage
+    from scrapy_poet import callback_for
 
 
     class BookPage(ItemWebPage):
-        """Extracts data from a book page"""
-
-        @property
-        def title(self):
-            """Extracts title from book page"""
-            return self.css("title::text").get()
+        """Individual book page on books.toscrape.com website, e.g.
+        http://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html
+        """
 
         def to_item(self):
-            """Converts page into an item"""
             return {
                 'url': self.url,
-                'name': self.title,
+                'name': self.css("title::text").get(),
             }
 
 
@@ -200,12 +214,20 @@ At the end of our job, our spider should look like this:
 
         name = 'books'
         start_urls = ['http://books.toscrape.com/']
-        parse_book = callback_for(BookPage)
+        parse_book = callback_for(BookPage)  # extract items from book pages
 
         def parse(self, response):
-            """Discovers book links and follows them"""
+            """Discover book links and follow them"""
             links = response.css('.image_container a')
             yield from response.follow_all(links, self.parse_book)
+
+
+It now looks similar to the original spider, but the item extraction logic
+is separated from the spider.
+
+On a surface, it looks just like a different way to organize Scrapy spider
+code - and indeed, it *is* just a different way to organize the code,
+but it opens some cool possibilities.
 
 Next steps
 ==========
@@ -213,6 +235,7 @@ Next steps
 Now that you know how scrapy-poet is supposed to work, what about trying to
 apply it to an existing or new Scrapy project?
 
-Also, please check :ref:`advanced` and refer to spiders in the "example" folder: https://github.com/scrapinghub/scrapy-poet/tree/master/example/example/spiders
+Also, please check :ref:`advanced` and refer to spiders in the "example"
+folder: https://github.com/scrapinghub/scrapy-poet/tree/master/example/example/spiders
 
 .. _Scrapy Tutorial: https://docs.scrapy.org/en/latest/intro/tutorial.html


### PR DESCRIPTION
This PR has small changes to the existing docs;  see commit messages for more detailed list of changes.

I think the version we have here is not final, it seems there are still things to improve:

* tutorial doesn't provide enough motivation - it shows what to do, but fails to explain why
* tutorial doesn't go far enough (e.g. no listing page objects) -  but it only makes sense to have these sections after fixing the "motivation" bit
* advanced docs may need to be split up for docs needed to provider writers and docs needed for the users. Currently it is written for provider writers, but it seems e.g. DummyResponse can be  explained in a simpler way for people who just need to use it.

I haven't touched those, let's keep if out of scope for this PR.