### PR TITLE
improve documentation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -4,6 +4,18 @@
 Advanced Usage
 ==============
 
+.. note::
+
+    This document assumes a good familiarity with ``web-poet`` concepts;
+    make sure you've read ``web-poet`` docs_.
+
+    This page is mostly aimed at developers who want to extend scrapy-poet,
+    not to developers who're writing extraction and crawling code using
+    scrapy-poet.
+
+
+.. _docs: https://web-poet.readthedocs.io/en/latest/
+
 Creating providers
 ==================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,11 +185,10 @@ epub_exclude_files = ['search.html']
 # -- Extension configuration -------------------------------------------------
 
 # -- Options for intersphinx extension ---------------------------------------
-
-# Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None, ),
     'scrapy': ('https://docs.scrapy.org/en/latest', None, ),
+    'web_poet': ('https://web-poet.readthedocs.io/en/latest/', None),
 }
 
 autodoc_default_options = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,16 +8,17 @@ web-poet_ defines a standard for writing reusable and portable
 extraction and crawling code; please check its docs_ to learn more.
 
 By using ``scrapy-poet`` you'll be organizing the spider code in a different
-way, which allows to separate extraction and crawling logic from the I/O,
-and from the Scrapy implementation details as well. It makes the code
-more testable and reusable.
+way, which separates extraction and crawling logic from the I/O,
+and from the Scrapy implementation details as well.
+It makes the code more testable and reusable.
 
 ``scrapy-poet`` also provides a way to integrate third-party APIs
 (like `Splash`_ and `AutoExtract`_) with the spider, without losing
-testability & reusability. Concrete integrations are not provided by
-``scrapy-poet``, but ``scrapy-poet`` makes them possbile.
+testability and reusability.
+Concrete integrations are not provided by ``scrapy-poet``, but
+``scrapy-poet`` makes them possbile.
 
-To get started, see :ref:`intro-install` and the :ref:`intro-tutorial`.
+To get started, see :ref:`intro-install` and :ref:`intro-tutorial`.
 
 :ref:`license` is BSD 3-clause.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,43 +1,41 @@
-.. scrapy-poet documentation master file, created by
-   sphinx-quickstart on Tue Apr 28 16:45:10 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 =========================
 scrapy-poet documentation
 =========================
 
-scrapy-poet easily integrates Page Objects created using `web-poet`_ with
-Scrapy through the configuration of a dependency injection middleware.
+scrapy-poet allows to use `web-poet`_ Page Objects with Scrapy.
 
-`web-poet`_ is used to make reusable Page Objects that separates
-extraction logic from crawling. They could be easily tested and distributed
-across different projects. Also, they could make use of different backends,
-for example, acquiring data from `Splash`_ and `AutoExtract`_ API.
+web-poet_ defines a standard for writing reusable and portable
+extraction and crawling code; please check its docs_ to learn more.
 
-The goal of this project is to provide a bridge between 
-:ref:`Scrapy Spiders <scrapy:topics-spiders>` and Page Objects.
+By using ``scrapy-poet`` you'll be organizing the spider code in a different
+way, which allows to separate extraction and crawling logic from the I/O,
+and from the Scrapy implementation details as well. It makes the code
+more testable and reusable.
 
-Please, see also our :ref:`intro-install` and our :ref:`intro-tutorial`
-for a quick start.
+``scrapy-poet`` also provides a way to integrate third-party APIs
+(like `Splash`_ and `AutoExtract`_) with the spider, without losing
+testability & reusability. Concrete integrations are not provided by
+``scrapy-poet``, but ``scrapy-poet`` makes them possbile.
+
+To get started, see :ref:`intro-install` and the :ref:`intro-tutorial`.
 
 :ref:`license` is BSD 3-clause.
 
 .. _`AutoExtract`: https://scrapinghub.com/autoextract
 .. _`Splash`: https://scrapinghub.com/splash
 .. _`web-poet`: https://github.com/scrapinghub/web-poet
+.. _docs: https://web-poet.readthedocs.io/en/latest/
 
 .. toctree::
    :caption: Getting started
-   :hidden:
+   :maxdepth: 1
 
    intro/install
    intro/tutorial
 
 .. toctree::
    :caption: Reference
-   :maxdepth: 2
-   :hidden:
+   :maxdepth: 1
 
    advanced
    api_reference

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -1,8 +1,8 @@
 .. _`intro-install`:
 
-==================
-Installation guide
-==================
+============
+Installation
+============
 
 Installing scrapy-poet
 ======================

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -7,6 +7,12 @@ Tutorial
 In this tutorial, we’ll assume that scrapy-poet is already installed on your
 system. If that’s not the case, see :ref:`intro-install`.
 
+.. note::
+
+    This tutorial can be followed without reading `web-poet docs`_, but
+    for the better understanding it is highly recommended to check them first.
+
+
 We are going to scrape `books.toscrape.com <http://books.toscrape.com/>`_,
 a website that lists books from famous authors.
 
@@ -19,6 +25,8 @@ This tutorial will walk you through these tasks:
 
 If you're not already familiar with Scrapy, and want to learn it quickly,
 the `Scrapy Tutorial`_ is a good resource.
+
+.. _web-poet docs: https://web-poet.readthedocs.io/en/latest/
 
 Creating a spider
 =================
@@ -76,7 +84,8 @@ Now we have a ``BookPage`` class that implements the ``to_item`` method.
 This class contains all logic necessary for extracting an item from
 an individual book page like
 http://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html,
-and nothing else.
+and nothing else. In particular, ``BookPage`` is now independent of Scrapy,
+and and is not doing any I/O.
 
 If we want, we can organize code in a different way, and e.g.
 extract a property from the ``to_item`` method:
@@ -112,7 +121,7 @@ To use scrapy-poet, enable its downloader middleware in ``settings.py``:
     }
 
 
-BookPage class we created previously can be used without scrapy-poet,
+``BookPage`` class we created previously can be used without scrapy-poet,
 and even without Scrapy (note that imports were from ``web_poet`` so far).
 
 ``scrapy-poet`` makes it easy to use ``web-poet`` Page Objects

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -10,7 +10,7 @@ system. If that’s not the case, see :ref:`intro-install`.
 .. note::
 
     This tutorial can be followed without reading `web-poet docs`_, but
-    for the better understanding it is highly recommended to check them first.
+    for a better understanding it is highly recommended to check them first.
 
 
 We are going to scrape `books.toscrape.com <http://books.toscrape.com/>`_,
@@ -84,8 +84,9 @@ Now we have a ``BookPage`` class that implements the ``to_item`` method.
 This class contains all logic necessary for extracting an item from
 an individual book page like
 http://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html,
-and nothing else. In particular, ``BookPage`` is now independent of Scrapy,
-and and is not doing any I/O.
+and nothing else.
+In particular, ``BookPage`` is now independent of Scrapy,
+and is not doing any I/O.
 
 If we want, we can organize code in a different way, and e.g.
 extract a property from the ``to_item`` method:


### PR DESCRIPTION
TODO:

- [x] overview
- [x] basic tutorial
- [x] advanced tutorial
- [x] check docstrings

I've made minor changes here and there, and added more links to web-poet docs. There are still sections can be explained a bit better (e.g. DummyResponse, from an user point of view), but I think this can be done later; having integrations available in third-party packages (e.g. for Splash and AutoExtract) could also allow to make the docs better later.