### PR TITLE
Add before and after hooks to providers

### DIFF
--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -154,11 +154,23 @@ def build_providers(instances) -> Dict[Type, PageObjectInputProvider]:
 def build_instances(plan: andi.Plan, providers):
     """Build the instances dict from a plan."""
     instances = {}
+
+    for cls, kwargs_spec in plan:
+        provider = providers.get(cls)
+        if provider and hasattr(provider, "__before__"):
+            provider.__before__()
+
     for cls, kwargs_spec in plan:
         if cls in providers:
             instances[cls] = yield maybeDeferred_coro(providers[cls])
         else:
             instances[cls] = cls(**kwargs_spec.kwargs(instances))
+
+    for cls, kwargs_spec in plan:
+        provider = providers.get(cls)
+        if provider and hasattr(provider, "__after__"):
+            provider.__after__()
+
     raise returnValue(instances)
 
 


### PR DESCRIPTION
Before and After hooks could be very helpful when implementing providers that are – somehow – aware of each other.

For example, you can aggregate similar providers that require external API calls and combine those requests into a single one, optimizing resources and reducing network overhead.

One could think that these hooks are against the web-poet proposal, but providers are specified by scrapy-poet and not by the former library. web-poet makes no assumptions about dependencies and how they should be fulfilled.

- [x] write tests
- [x] implement feature
- [ ] update documentation