### PR TITLE
New provider interface

### DIFF
--- a/scrapy_poet/middleware.py
+++ b/scrapy_poet/middleware.py
@@ -74,9 +74,11 @@ class InjectionMiddleware:
         }
         assert set(external_dependencies.keys()) == _SCRAPY_PROVIDED_CLASSES
 
+        providers = spider.settings["SCRAPY_POET_PROVIDERS"]
+
         # Build all instances declared as dependencies
-        plan = utils.build_plan(callback)
-        instances = yield from utils.build_instances(plan, external_dependencies)
+        plan = utils.build_plan(callback, providers)
+        instances = yield from utils.build_instances(plan, providers, external_dependencies)
 
         # Fill the callback arguments with the created instances
         for arg, value in plan.final_kwargs(instances).items():

--- a/scrapy_poet/middleware.py
+++ b/scrapy_poet/middleware.py
@@ -2,7 +2,6 @@
 responsible for injecting Page Input dependencies before the request callbacks
 are executed.
 """
-
 from scrapy import Spider
 from scrapy.crawler import Crawler
 from scrapy.http import Request, Response
@@ -11,7 +10,47 @@ from scrapy.statscollectors import StatsCollector
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 from scrapy_poet import utils
-from scrapy_poet.utils import _SCRAPY_PROVIDED_CLASSES
+from scrapy_poet.page_input_providers import PageObjectInputProvider
+from scrapy_poet.utils import _SCRAPY_PROVIDED_CLASSES, load_provider_classes
+
+
+Provider = PageObjectInputProvider
+
+
+class ProviderManager:
+
+    def __init__(self, crawler: Crawler):
+        self.crawler = crawler
+        self.providers = self.load_providers()
+
+    @inlineCallbacks
+    def __call__(self, spider: Spider, request: Request, response: Response):
+        callback = utils.get_callback(request, spider)
+        plan = utils.build_plan(callback, self.providers)
+
+        scrapy_provided_dependencies = {
+            Spider: spider,
+            Request: request,
+            Response: response,
+            Crawler: spider.crawler,
+            Settings: spider.settings,
+            StatsCollector: spider.crawler.stats,
+        }
+        assert scrapy_provided_dependencies.keys() == _SCRAPY_PROVIDED_CLASSES
+
+        provider_instances = yield from utils.build_instances(
+            plan,
+            self.providers,
+            scrapy_provided_dependencies
+        )
+        final_kwargs = plan.final_kwargs(provider_instances)
+        raise returnValue(final_kwargs)
+
+    def load_providers(self):
+        return [
+            cls(self.crawler)
+            for cls in load_provider_classes(self.crawler.settings)
+        ]
 
 
 class InjectionMiddleware:
@@ -20,6 +59,14 @@ class InjectionMiddleware:
     * check if request downloads could be skipped
     * inject dependencies before request callbacks are executed
     """
+    def __init__(self, crawler):
+        self.crawler = crawler
+        self.provider_manager = ProviderManager(crawler)
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
     def process_request(self, request: Request, spider: Spider):
         """This method checks if the request is really needed and if its
         download could be skipped by trying to infer if a ``Response``
@@ -34,7 +81,8 @@ class InjectionMiddleware:
         actually using another source like external APIs such as Scrapinghub's
         Auto Extract.
         """
-        if utils.is_response_going_to_be_used(request, spider):
+        providers = self.provider_manager.providers
+        if utils.is_response_going_to_be_used(request, spider, providers):
             return
 
         spider.logger.debug(f'Skipping download of {request}')
@@ -63,25 +111,13 @@ class InjectionMiddleware:
         - :class:`~scrapy.statscollectors.StatsCollector`
         """
         # Find out the dependencies
-        callback = utils.get_callback(request, spider)
-        external_dependencies = {
-            Spider: spider,
-            Request: request,
-            Response: response,
-            Crawler: spider.crawler,
-            Settings: spider.settings,
-            StatsCollector: spider.crawler.stats,
-        }
-        assert set(external_dependencies.keys()) == _SCRAPY_PROVIDED_CLASSES
-
-        providers = spider.settings["SCRAPY_POET_PROVIDERS"]
-
-        # Build all instances declared as dependencies
-        plan = utils.build_plan(callback, providers)
-        instances = yield from utils.build_instances(plan, providers, external_dependencies)
-
+        final_kwargs = yield from self.provider_manager(
+            spider,
+            request,
+            response
+        )
         # Fill the callback arguments with the created instances
-        for arg, value in plan.final_kwargs(instances).items():
+        for arg, value in final_kwargs.items():
             # Precedence of user callback arguments
             if arg not in request.cb_kwargs:
                 request.cb_kwargs[arg] = value

--- a/scrapy_poet/middleware.py
+++ b/scrapy_poet/middleware.py
@@ -10,11 +10,7 @@ from scrapy.statscollectors import StatsCollector
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 from scrapy_poet import utils
-from scrapy_poet.page_input_providers import PageObjectInputProvider
 from scrapy_poet.utils import _SCRAPY_PROVIDED_CLASSES, load_provider_classes
-
-
-Provider = PageObjectInputProvider
 
 
 class ProviderManager:

--- a/scrapy_poet/middleware.py
+++ b/scrapy_poet/middleware.py
@@ -64,7 +64,7 @@ class InjectionMiddleware:
         """
         # Find out the dependencies
         callback = utils.get_callback(request, spider)
-        dependencies = {
+        external_dependencies = {
             Spider: spider,
             Request: request,
             Response: response,
@@ -72,13 +72,11 @@ class InjectionMiddleware:
             Settings: spider.settings,
             StatsCollector: spider.crawler.stats,
         }
-        assert set(dependencies.keys()) == _SCRAPY_PROVIDED_CLASSES
-
-        plan = utils.build_plan(callback)
-        provider_instances = utils.build_providers(dependencies)
+        assert set(external_dependencies.keys()) == _SCRAPY_PROVIDED_CLASSES
 
         # Build all instances declared as dependencies
-        instances = yield from utils.build_instances(plan, provider_instances)
+        plan = utils.build_plan(callback)
+        instances = yield from utils.build_instances(plan, external_dependencies)
 
         # Fill the callback arguments with the created instances
         for arg, value in plan.final_kwargs(instances).items():

--- a/scrapy_poet/middleware.py
+++ b/scrapy_poet/middleware.py
@@ -73,11 +73,12 @@ class InjectionMiddleware:
             StatsCollector: spider.crawler.stats,
         }
         assert set(dependencies.keys()) == _SCRAPY_PROVIDED_CLASSES
-        plan, provider_instances = utils.build_plan(callback, dependencies)
+
+        plan = utils.build_plan(callback)
+        provider_instances = utils.build_providers(dependencies)
 
         # Build all instances declared as dependencies
-        instances = yield from utils.build_instances(
-            plan.dependencies, provider_instances)
+        instances = yield from utils.build_instances(plan, provider_instances)
 
         # Fill the callback arguments with the created instances
         for arg, value in plan.final_kwargs(instances).items():

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -11,8 +11,6 @@ import typing
 from scrapy.http import Response
 from web_poet.page_inputs import ResponseData
 
-providers = set()
-
 
 class PageObjectInputProvider(abc.ABC):
     """This is an abstract class for describing Page Object Input Providers."""
@@ -57,10 +55,6 @@ class PageObjectInputProvider(abc.ABC):
     @abc.abstractmethod
     def __call__(self, provided_classes: typing.Set[typing.Type]) -> typing.Dict[typing.Type, typing.Any]:
         """This method is responsible for building Page Input dependencies."""
-
-    @classmethod
-    def register(cls):
-        providers.add(cls)
 
 
 class ResponseDataProvider(PageObjectInputProvider):

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -53,7 +53,7 @@ class PageObjectInputProvider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def __call__(self, provided_classes: typing.Set[typing.Type]) -> typing.Dict[typing.Type, typing.Any]:
+    def __call__(self, to_provide: typing.Set[typing.Type]) -> typing.Dict[typing.Type, typing.Any]:
         """This method is responsible for building Page Input dependencies."""
 
 
@@ -66,7 +66,7 @@ class ResponseDataProvider(PageObjectInputProvider):
         """This class receives a Scrapy ``Response`` as a dependency."""
         self.response = response
 
-    def __call__(self, provided_classes: typing.Set[typing.Type]):
+    def __call__(self, to_provide: typing.Set[typing.Type]):
         """Builds a ``ResponseData`` instance using a Scrapy ``Response``."""
         return {
             ResponseData: ResponseData(

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -83,7 +83,7 @@ class ResponseDataProvider(PageObjectInputProvider):
         """This class receives a Scrapy ``Response`` as a dependency."""
         self.response = response
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, provided_classes: typing.Set[typing.Type]):
         """Builds a ``ResponseData`` instance using a Scrapy ``Response``."""
         return {
             ResponseData: ResponseData(

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -9,6 +9,7 @@ import abc
 import typing
 
 from scrapy.http import Response
+from scrapy.crawler import Crawler
 from web_poet.page_inputs import ResponseData
 
 
@@ -17,7 +18,7 @@ class PageObjectInputProvider(abc.ABC):
 
     provided_classes: typing.Set[typing.Type]
 
-    def __init__(self):
+    def __init__(self, crawler: Crawler):
         """You can override this method to receive external dependencies.
 
         Currently, scrapy-poet is able to inject instances of the following
@@ -51,6 +52,7 @@ class PageObjectInputProvider(abc.ABC):
                         assert isinstance(response, TextResponse)
                         self.response = response
         """
+        self.crawler = crawler
 
     @abc.abstractmethod
     def __call__(self, to_provide: typing.Set[typing.Type]) -> typing.Dict[typing.Type, typing.Any]:
@@ -62,15 +64,11 @@ class ResponseDataProvider(PageObjectInputProvider):
 
     provided_classes = {ResponseData}
 
-    def __init__(self, response: Response):
-        """This class receives a Scrapy ``Response`` as a dependency."""
-        self.response = response
-
-    def __call__(self, to_provide: typing.Set[typing.Type]):
+    def __call__(self, to_provide: typing.Set[typing.Type], response: Response):
         """Builds a ``ResponseData`` instance using a Scrapy ``Response``."""
         return {
             ResponseData: ResponseData(
-                url=self.response.url,
-                html=self.response.text
+                url=response.url,
+                html=response.text
             )
         }

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -58,22 +58,11 @@ class PageObjectInputProvider(abc.ABC):
     def __call__(self, provided_classes: typing.Set[typing.Type]) -> typing.Dict[typing.Type, typing.Any]:
         """This method is responsible for building Page Input dependencies."""
 
-
-def provides():
-    """This decorator should be used with classes that inherits from
-    ``PageObjectInputProvider`` in order to automatically register them as
-    providers.
-
-    See ``ResponseDataProvider``'s implementation for an example.
-    """
-    def decorator(provider_class: typing.Type[PageObjectInputProvider]):
-        providers.add(provider_class)
-        return provider_class
-
-    return decorator
+    @classmethod
+    def register(cls):
+        providers.add(cls)
 
 
-@provides()
 class ResponseDataProvider(PageObjectInputProvider):
     """This class provides ``web_poet.page_inputs.ResponseData`` instances."""
 

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -152,7 +152,7 @@ def build_provider(provider: Type[PageObjectInputProvider],
 def build_instances(plan: andi.Plan, providers: List[Type[PageObjectInputProvider]],
                     external_dependencies: Dict[Callable, Any]):
     """Build the instances dict from a plan including external dependencies."""
-    instances = {}
+    instances = {}  # type: ignore
 
     # Build dependencies handled by registered providers
     dependencies_set = set(cls for cls, kwargs_spec in plan.dependencies)

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -104,10 +104,13 @@ def discover_callback_providers(callback):
         is_injectable=is_injectable,
         externally_provided=set.union(*(p.provided_classes for p in providers)),
     )
+    result = set()
     for obj, _ in plan:
         for provider in providers:
             if obj in provider.provided_classes:
-                yield provider
+                result.add(provider)
+
+    return result
 
 
 def is_response_going_to_be_used(request, spider):

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -158,6 +158,7 @@ def build_instances(plan: andi.Plan, providers: List[Type[PageObjectInputProvide
     dependencies_set = set(cls for cls, kwargs_spec in plan.dependencies)
     for provider in providers:
         provided_classes = dependencies_set & provider.provided_classes
+        provided_classes -= instances.keys()
         if not provided_classes:
             continue
 

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -158,7 +158,7 @@ def build_instances(plan: andi.Plan, providers: List[Type[PageObjectInputProvide
     dependencies_set = set(cls for cls, kwargs_spec in plan.dependencies)
     for provider in providers:
         provided_classes = dependencies_set & provider.provided_classes
-        provided_classes -= instances.keys()
+        provided_classes -= instances.keys()  # ignore already provided types
         if not provided_classes:
             continue
 

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -159,12 +159,10 @@ def build_instances(plan: andi.Plan, provider_instances: Set[PageObjectInputProv
     """Build the instances dict from a plan."""
     instances = {}
 
-    dependencies = dict(plan.dependencies)
-
     for provider in provider_instances:
         # Discover classes being provided by this provider
         provided_classes = set()
-        for cls in dependencies.keys():
+        for cls, kwargs_spec in plan.dependencies:
             if cls in provider.provided_classes:
                 provided_classes.add(cls)
 
@@ -177,7 +175,7 @@ def build_instances(plan: andi.Plan, provider_instances: Set[PageObjectInputProv
             instances[provided_class] = instance[provided_class]
 
     # Build missing dependencies not addressed by previous step
-    for cls, kwargs_spec in dependencies.items():
+    for cls, kwargs_spec in plan.dependencies:
         if cls not in instances.keys():
             instances[cls] = cls(**kwargs_spec.kwargs(instances))
 

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -29,6 +29,11 @@ _SCRAPY_PROVIDED_CLASSES = {
 }
 
 
+def get_provided_classes_from_providers() -> Set[Type]:
+    provided_classes = (p.provided_classes for p in providers)
+    return set.union(*provided_classes)
+
+
 def get_callback(request, spider):
     """Get request.callback of a scrapy.Request, as a callable."""
     if request.callback is None:
@@ -102,7 +107,7 @@ def discover_callback_providers(callback):
     plan = andi.plan(
         callback,
         is_injectable=is_injectable,
-        externally_provided=set.union(*(p.provided_classes for p in providers)),
+        externally_provided=get_provided_classes_from_providers(),
     )
     result = set()
     for obj, _ in plan:
@@ -131,7 +136,7 @@ def build_plan(callback) -> andi.Plan:
     return andi.plan(
         callback,
         is_injectable=is_injectable,
-        externally_provided=set.union(*(p.provided_classes for p in providers))
+        externally_provided=get_provided_classes_from_providers(),
     )
 
 

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -152,7 +152,7 @@ def build_provider(provider: Type[PageObjectInputProvider],
 def build_instances(plan: andi.Plan, providers: List[Type[PageObjectInputProvider]],
                     external_dependencies: Dict[Callable, Any]):
     """Build the instances dict from a plan including external dependencies."""
-    instances = {}  # type: ignore
+    instances: Dict[Callable, Any] = {}
 
     # Build dependencies handled by registered providers
     dependencies_set = set(cls for cls, kwargs_spec in plan.dependencies)

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -164,6 +164,13 @@ def build_instances(plan: andi.Plan, providers: List[Type[PageObjectInputProvide
 
         provider_instance = build_provider(provider, external_dependencies)
         results = yield maybeDeferred_coro(provider_instance, provided_classes)
+        extra_classes = results.keys() - provider.provided_classes
+        if extra_classes:
+            raise RuntimeError(
+                f"{provider} has returned {extra_classes} but they're not "
+                f"listed as provided classes {provider.provided_classes}"
+            )
+
         instances.update(results)
 
     # Build remaining dependencies

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -155,9 +155,9 @@ def build_instances(plan: andi.Plan, providers: List[Type[PageObjectInputProvide
     instances = {}
 
     # Build dependencies handled by registered providers
-    plan_dependencies = dict(plan.dependencies)
+    dependencies_set = set(cls for cls, kwargs_spec in plan.dependencies)
     for provider in providers:
-        provided_classes = plan_dependencies.keys() & provider.provided_classes
+        provided_classes = dependencies_set & provider.provided_classes
         if not provided_classes:
             continue
 
@@ -166,7 +166,7 @@ def build_instances(plan: andi.Plan, providers: List[Type[PageObjectInputProvide
         instances.update(results)
 
     # Build remaining dependencies
-    for cls, kwargs_spec in plan_dependencies.items():
+    for cls, kwargs_spec in plan.dependencies:
         if cls not in instances.keys():
             instances[cls] = cls(**kwargs_spec.kwargs(instances))
 

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -141,7 +141,7 @@ def build_plan(callback) -> andi.Plan:
 
 
 def build_provider(provider: Type[PageObjectInputProvider],
-                   external_dependencies: Dict[Type, Any]) -> PageObjectInputProvider:
+                   external_dependencies: Dict[Callable, Any]) -> PageObjectInputProvider:
     kwargs = andi.plan(
         provider,
         is_injectable=is_injectable,
@@ -152,7 +152,7 @@ def build_provider(provider: Type[PageObjectInputProvider],
 
 
 @inlineCallbacks
-def build_instances(plan: andi.Plan, external_dependencies: Dict[Type, Any]) -> Dict[Type, Any]:
+def build_instances(plan: andi.Plan, external_dependencies: Dict[Callable, Any]):
     """Build the instances dict from a plan including external dependencies."""
     instances = {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,6 @@ from scrapy.settings import Settings
 
 from scrapy_poet.page_input_providers import ResponseDataProvider
 
-ResponseDataProvider.register()
-
 
 @pytest.fixture()
 def settings(request):
@@ -17,5 +15,8 @@ def settings(request):
         DOWNLOADER_MIDDLEWARES={
             'scrapy_poet.InjectionMiddleware': 543,
         },
+        SCRAPY_POET_PROVIDERS=[
+            ResponseDataProvider,
+        ],
     )
     return Settings(s)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import pytest
 from scrapy.settings import Settings
 
+from scrapy_poet.page_input_providers import ResponseDataProvider
+
+ResponseDataProvider.register()
+
 
 @pytest.fixture()
 def settings(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def settings(request):
         DOWNLOADER_MIDDLEWARES={
             'scrapy_poet.InjectionMiddleware': 543,
         },
-        SCRAPY_POET_PROVIDERS=[
+        SCRAPY_POET_PROVIDER_CLASSES=[
             ResponseDataProvider,
         ],
     )

--- a/tests/test_callback_for.py
+++ b/tests/test_callback_for.py
@@ -5,7 +5,6 @@ from scrapy.utils.reqser import request_to_dict
 from web_poet.pages import ItemPage, ItemWebPage
 from scrapy_poet.utils import (
     callback_for,
-    is_response_going_to_be_used,
     DummyResponse,
 )
 
@@ -74,14 +73,12 @@ def test_instance_method_callback():
     assert isinstance(request_dict, dict)
     assert request_dict['url'] == 'http://example.com/'
     assert request_dict['callback'] == 'parse_item'
-    assert is_response_going_to_be_used(request, spider) is False
 
     request = scrapy.Request('http://example.com/', callback=spider.parse_web)
     request_dict = request_to_dict(request, spider)
     assert isinstance(request_dict, dict)
     assert request_dict['url'] == 'http://example.com/'
     assert request_dict['callback'] == 'parse_web'
-    assert is_response_going_to_be_used(request, spider) is True
 
 
 def test_inline_callback():

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -111,16 +111,20 @@ class ProvidedAsyncTest:
     response: ResponseData  # it should be None because this class is provided
 
 
-@provides(ProvidedAsyncTest)
+@provides()
 class ResponseDataProvider(PageObjectInputProvider):
+
+    provided_classes = {ProvidedAsyncTest}
 
     def __init__(self, response: scrapy.http.Response):
         self.response = response
 
     @inlineCallbacks
-    def __call__(self):
+    def __call__(self, *args, **kwargs):
         five = yield deferToThread(lambda: 5)
-        raise returnValue(ProvidedAsyncTest(f"Provided {five}!", None))
+        raise returnValue({
+            ProvidedAsyncTest: ProvidedAsyncTest(f"Provided {five}!", None)
+        })
 
 
 @attr.s(auto_attribs=True)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -130,7 +130,7 @@ class CustomResponseDataProvider(PageObjectInputProvider):
         self.response = response
 
     @inlineCallbacks
-    def __call__(self, provided_classes):
+    def __call__(self, to_provide):
         five = yield deferToThread(lambda: 5)
         raise returnValue({
             ProvidedAsyncTest: ProvidedAsyncTest(f"Provided {five}!", None)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -12,7 +12,7 @@ import attr
 
 from scrapy_poet import callback_for
 from web_poet.pages import WebPage, ItemWebPage
-from scrapy_poet.page_input_providers import provides, PageObjectInputProvider
+from scrapy_poet.page_input_providers import PageObjectInputProvider
 from web_poet.page_inputs import ResponseData
 from scrapy_poet.utils import DummyResponse
 from tests.utils import HtmlResource, crawl_items, capture_exceptions, \
@@ -111,7 +111,6 @@ class ProvidedAsyncTest:
     response: ResponseData  # it should be None because this class is provided
 
 
-@provides()
 class ResponseDataProvider(PageObjectInputProvider):
 
     provided_classes = {ProvidedAsyncTest}
@@ -125,6 +124,9 @@ class ResponseDataProvider(PageObjectInputProvider):
         raise returnValue({
             ProvidedAsyncTest: ProvidedAsyncTest(f"Provided {five}!", None)
         })
+
+
+ResponseDataProvider.register()
 
 
 @attr.s(auto_attribs=True)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -119,7 +119,7 @@ class ResponseDataProvider(PageObjectInputProvider):
         self.response = response
 
     @inlineCallbacks
-    def __call__(self, *args, **kwargs):
+    def __call__(self, provided_classes):
         five = yield deferToThread(lambda: 5)
         raise returnValue({
             ProvidedAsyncTest: ProvidedAsyncTest(f"Provided {five}!", None)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -43,7 +43,7 @@ def spider_for(injectable: Type):
 
         url = None
         custom_settings = {
-            "SCRAPY_POET_PROVIDERS": [
+            "SCRAPY_POET_PROVIDER_CLASSES": [
                 CustomResponseDataProvider,
                 ExtraClassDataProvider,
                 ResponseDataProvider,
@@ -128,11 +128,8 @@ class CustomResponseDataProvider(PageObjectInputProvider):
 
     provided_classes = {ProvidedAsyncTest}
 
-    def __init__(self, response: scrapy.http.Response):
-        self.response = response
-
     @inlineCallbacks
-    def __call__(self, to_provide):
+    def __call__(self, to_provide, response: scrapy.http.Response):
         five = yield deferToThread(lambda: 5)
         raise returnValue({
             ProvidedAsyncTest: ProvidedAsyncTest(f"Provided {five}!", None)
@@ -191,7 +188,7 @@ class MultiArgsCallbackSpider(scrapy.Spider):
 
     url = None
     custom_settings = {
-        "SCRAPY_POET_PROVIDERS": [
+        "SCRAPY_POET_PROVIDER_CLASSES": [
             CustomResponseDataProvider,
             ResponseDataProvider,
         ]

--- a/tests/test_scrapy_dependencies.py
+++ b/tests/test_scrapy_dependencies.py
@@ -38,16 +38,20 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
     class PageData:
         scrapy_class: str
 
-    @provides(PageData)
+    @provides()
     class PageDataProvider(PageObjectInputProvider):
+
+        provided_classes = {PageData}
 
         def __init__(self, obj: scrapy_class):
             self.obj = obj
 
-        def __call__(self):
-            return PageData(
-                scrapy_class=scrapy_class.__name__,
-            )
+        def __call__(self, *args, **kwargs):
+            return {
+                PageData: PageData(
+                    scrapy_class=scrapy_class.__name__,
+                )
+            }
 
     @attr.s(auto_attribs=True)
     class Page(ItemWebPage):

--- a/tests/test_scrapy_dependencies.py
+++ b/tests/test_scrapy_dependencies.py
@@ -6,10 +6,7 @@ from scrapy.http import Request
 from web_poet.pages import ItemWebPage
 
 from scrapy_poet.utils import _SCRAPY_PROVIDED_CLASSES
-from scrapy_poet.page_input_providers import (
-    provides,
-    PageObjectInputProvider,
-)
+from scrapy_poet.page_input_providers import PageObjectInputProvider
 
 from tests.utils import crawl_items, crawl_single_item, HtmlResource
 
@@ -38,7 +35,6 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
     class PageData:
         scrapy_class: str
 
-    @provides()
     class PageDataProvider(PageObjectInputProvider):
 
         provided_classes = {PageData}
@@ -52,6 +48,8 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
                     scrapy_class=scrapy_class.__name__,
                 )
             }
+
+    PageDataProvider.register()
 
     @attr.s(auto_attribs=True)
     class Page(ItemWebPage):

--- a/tests/test_scrapy_dependencies.py
+++ b/tests/test_scrapy_dependencies.py
@@ -42,7 +42,7 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
         def __init__(self, obj: scrapy_class):
             self.obj = obj
 
-        def __call__(self, *args, **kwargs):
+        def __call__(self, provided_classes):
             return {
                 PageData: PageData(
                     scrapy_class=scrapy_class.__name__,

--- a/tests/test_scrapy_dependencies.py
+++ b/tests/test_scrapy_dependencies.py
@@ -6,7 +6,10 @@ from scrapy.http import Request
 from web_poet.pages import ItemWebPage
 
 from scrapy_poet.utils import _SCRAPY_PROVIDED_CLASSES
-from scrapy_poet.page_input_providers import PageObjectInputProvider
+from scrapy_poet.page_input_providers import (
+    PageObjectInputProvider,
+    ResponseDataProvider,
+)
 
 from tests.utils import crawl_items, crawl_single_item, HtmlResource
 
@@ -49,8 +52,6 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
                 )
             }
 
-    PageDataProvider.register()
-
     @attr.s(auto_attribs=True)
     class Page(ItemWebPage):
 
@@ -65,6 +66,12 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
 
         name = "my_spider"
         url = None
+        custom_settings = {
+            "SCRAPY_POET_PROVIDERS": [
+                ResponseDataProvider,
+                PageDataProvider,
+            ]
+        }
 
         def start_requests(self):
             yield Request(url=self.url, callback=self.parse)

--- a/tests/test_scrapy_dependencies.py
+++ b/tests/test_scrapy_dependencies.py
@@ -42,10 +42,7 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
 
         provided_classes = {PageData}
 
-        def __init__(self, obj: scrapy_class):
-            self.obj = obj
-
-        def __call__(self, to_provide):
+        def __call__(self, to_provide, obj: scrapy_class):
             return {
                 PageData: PageData(
                     scrapy_class=scrapy_class.__name__,
@@ -67,7 +64,7 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
         name = "my_spider"
         url = None
         custom_settings = {
-            "SCRAPY_POET_PROVIDERS": [
+            "SCRAPY_POET_PROVIDER_CLASSES": [
                 ResponseDataProvider,
                 PageDataProvider,
             ]

--- a/tests/test_scrapy_dependencies.py
+++ b/tests/test_scrapy_dependencies.py
@@ -45,7 +45,7 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
         def __init__(self, obj: scrapy_class):
             self.obj = obj
 
-        def __call__(self, provided_classes):
+        def __call__(self, to_provide):
             return {
                 PageData: PageData(
                     scrapy_class=scrapy_class.__name__,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,6 @@ from scrapy.http import TextResponse
 from scrapy_poet.page_input_providers import (
     PageObjectInputProvider,
     ResponseDataProvider,
-    provides,
 )
 from web_poet.pages import ItemPage, WebPage
 
@@ -32,7 +31,6 @@ class FakeProductResponse:
     data: Dict[str, Any]
 
 
-@provides()
 class DummyProductProvider(PageObjectInputProvider):
 
     provided_classes = {DummyProductResponse}
@@ -52,7 +50,9 @@ class DummyProductProvider(PageObjectInputProvider):
         }
 
 
-@provides()
+DummyProductProvider.register()
+
+
 class FakeProductProvider(PageObjectInputProvider):
 
     provided_classes = {FakeProductResponse}
@@ -67,6 +67,9 @@ class FakeProductProvider(PageObjectInputProvider):
         return {
             DummyProductResponse: DummyProductResponse(data=data)
         }
+
+
+FakeProductProvider.register()
 
 
 class TextProductProvider(ResponseDataProvider):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from scrapy_poet.page_input_providers import (
 from web_poet.pages import ItemPage, WebPage
 
 from scrapy_poet.utils import (
+    callback_for,
     get_callback,
     is_callback_using_response,
     is_provider_using_response,
@@ -121,7 +122,9 @@ class BookPage(WebPage):
 
 
 class MySpider(scrapy.Spider):
+
     name = 'foo'
+    callback_for_parse = callback_for(DummyProductPage)
 
     def parse(self, response):
         pass
@@ -201,6 +204,9 @@ def test_is_callback_using_response():
     assert is_callback_using_response(spider.parse10) is False
     assert is_callback_using_response(spider.parse11) is True
     assert is_callback_using_response(spider.parse12) is True
+    # Callbacks created with the callback_for function won't make use of
+    # the response, but their providers might use them.
+    assert is_callback_using_response(spider.callback_for_parse) is False
 
 
 def test_is_response_going_to_be_used():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,33 +32,41 @@ class FakeProductResponse:
     data: Dict[str, Any]
 
 
-@provides(DummyProductResponse)
+@provides()
 class DummyProductProvider(PageObjectInputProvider):
+
+    provided_classes = {DummyProductResponse}
 
     def __init__(self, request: scrapy.Request):
         self.request = request
 
-    def __call__(self):
+    def __call__(self, *args, **kwargs):
         data = {
             'product': {
                 'url': self.request.url,
                 'name': 'Sample',
             },
         }
-        return DummyProductResponse(data=data)
+        return {
+            DummyProductResponse: DummyProductResponse(data=data)
+        }
 
 
-@provides(FakeProductResponse)
+@provides()
 class FakeProductProvider(PageObjectInputProvider):
 
-    def __call__(self):
+    provided_classes = {FakeProductResponse}
+
+    def __call__(self, *args, **kwargs):
         data = {
             'product': {
                 'url': 'http://example.com/sample',
                 'name': 'Sample',
             },
         }
-        return DummyProductResponse(data=data)
+        return {
+            DummyProductResponse: DummyProductResponse(data=data)
+        }
 
 
 class TextProductProvider(ResponseDataProvider):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ class DummyProductProvider(PageObjectInputProvider):
     def __init__(self, request: scrapy.Request):
         self.request = request
 
-    def __call__(self, provided_classes):
+    def __call__(self, to_provide):
         data = {
             'product': {
                 'url': self.request.url,
@@ -56,7 +56,7 @@ class FakeProductProvider(PageObjectInputProvider):
 
     provided_classes = {FakeProductResponse}
 
-    def __call__(self, provided_classes):
+    def __call__(self, to_provide):
         data = {
             'product': {
                 'url': 'http://example.com/sample',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,7 +38,7 @@ class DummyProductProvider(PageObjectInputProvider):
     def __init__(self, request: scrapy.Request):
         self.request = request
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, provided_classes):
         data = {
             'product': {
                 'url': self.request.url,
@@ -57,7 +57,7 @@ class FakeProductProvider(PageObjectInputProvider):
 
     provided_classes = {FakeProductResponse}
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, provided_classes):
         data = {
             'product': {
                 'url': 'http://example.com/sample',


### PR DESCRIPTION
This new interface expects providers to specify a class method with a set of provided classes. 

When calling providers with this new interface, injection middleware should pass an argument with a sub-set of those provided classes that are currently being provided. This way, the provider could return a dictionary with its keys being the classes specified in this sub-set and the values being the desired output.

Providers that need to provide instances for a single class should just go ahead and specify a set with a single element.

- [ ] update documentation