### PR TITLE
[WIP] Hierarchichal overrides using regex

### DIFF
--- a/tests/test_regex_overrides.py
+++ b/tests/test_regex_overrides.py
@@ -1,0 +1,115 @@
+from typing import Mapping
+
+import pytest
+
+from scrapy import Request, Spider
+from scrapy.utils.test import get_crawler
+from scrapy_poet.overrides import RegexOverridesRegistry, \
+    PerDomainOverridesRegistry
+
+
+class _str(str, Mapping):  # type: ignore
+    """Trick to use strings as overrides dicts for testing"""
+    ...
+
+
+def _r(url: str):
+    return Request(url)
+
+
+@pytest.fixture
+def reg():
+    return RegexOverridesRegistry()
+
+
+class TestRegexOverridesRegistry:
+
+    def test_replace(self, reg):
+        reg.register("toscrape.com", _str("ORIGINAL"))
+        assert reg.overrides_for(_r("http://toscrape.com:442/path")) == "ORIGINAL"
+        reg.register("toscrape.com", _str("REPLACED"))
+        assert reg.overrides_for(_r("http://www.toscrape.com/path")) == "REPLACED"
+        assert len(reg.rules) == 1
+
+    def test_init_and_global(self):
+        overrides = {
+            "": _str("GLOBAL"),
+            "toscrape.com": _str("TOSCRAPE")
+        }
+        reg = RegexOverridesRegistry(overrides)
+        assert reg.overrides_for(_r("http://example.com/blabla")) == "GLOBAL"
+        assert reg.overrides_for(_r("http://toscrape.com/blabla")) == "TOSCRAPE"
+
+    def test_register(self, reg):
+        assert reg.overrides_for(_r("http://books.toscrape.com/")) == {}
+
+        reg.register("books.toscrape.com", _str("BOOKS_TO_SCRAPE"))
+        assert reg.overrides_for(_r("http://books.toscrape.com/")) == "BOOKS_TO_SCRAPE"
+        assert reg.overrides_for(_r("http://books.toscrape.com/path")) == "BOOKS_TO_SCRAPE"
+        assert reg.overrides_for(_r("http://toscrape.com/")) == {}
+
+        reg.register("toscrape.com", _str("TO_SCRAPE"))
+        assert reg.overrides_for(_r("http://books.toscrape.com/")) == "BOOKS_TO_SCRAPE"
+        assert reg.overrides_for(_r("http://books.toscrape.com/path")) == "BOOKS_TO_SCRAPE"
+        assert reg.overrides_for(_r("http://toscrape.com/")) == "TO_SCRAPE"
+        assert reg.overrides_for(_r("http://www.toscrape.com/")) == "TO_SCRAPE"
+        assert reg.overrides_for(_r("http://toscrape.com/path")) == "TO_SCRAPE"
+        assert reg.overrides_for(_r("http://zz.com")) == {}
+
+        reg.register("books.toscrape.com/category/books/classics_6/", _str("CLASSICS"))
+        assert reg.overrides_for(_r("http://books.toscrape.com/path?arg=1")) == "BOOKS_TO_SCRAPE"
+        assert reg.overrides_for(_r("http://toscrape.com")) == "TO_SCRAPE"
+        assert reg.overrides_for(_r("http://aa.com")) == {}
+        assert reg.overrides_for(
+            _r("https://books.toscrape.com/category/books/classics_6")) == "CLASSICS"
+        assert reg.overrides_for(
+            _r("http://books.toscrape.com/category/books/classics_6/path")) == "CLASSICS"
+        assert reg.overrides_for(
+            _r("http://books.toscrape.com/category/books/")) == "BOOKS_TO_SCRAPE"
+
+    def test_from_crawler(self):
+        crawler = get_crawler(Spider)
+        reg = RegexOverridesRegistry.from_crawler(crawler)
+        assert len(reg.rules) == 0
+
+        settings = {
+            "SCRAPY_POET_OVERRIDES": {
+                "toscrape.com": _str("TOSCRAPE")
+            }
+        }
+        crawler = get_crawler(Spider, settings)
+        reg = RegexOverridesRegistry.from_crawler(crawler)
+        assert len(reg.rules) == 1
+        assert reg.overrides_for(_r("http://toscrape.com/path")) == "TOSCRAPE"
+
+    def test_domain_subdomain_case(self, reg):
+        reg.register("toscrape.com", _str("DOMAIN"))
+        reg.register("books.toscrape.com", _str("SUBDOMAIN"))
+        assert reg.overrides_for(_r("http://toscrape.com/blabla")) == "DOMAIN"
+        assert reg.overrides_for(_r("http://cars.toscrape.com/")) == "DOMAIN"
+        assert reg.overrides_for(_r("http://books2.toscrape.com:123/blabla")) == "DOMAIN"
+        assert reg.overrides_for(_r("https://mybooks.toscrape.com/blabla")) == "DOMAIN"
+        assert reg.overrides_for(_r("http://books.toscrape.com/blabla")) == "SUBDOMAIN"
+        assert reg.overrides_for(_r("http://www.books.toscrape.com")) == "SUBDOMAIN"
+        assert reg.overrides_for(_r("http://uk.books.toscrape.com/blabla")) == "SUBDOMAIN"
+
+    def test_common_prefix_domains(self, reg):
+        reg.register("toscrape.com", _str("TOSCRAPE"))
+        reg.register("toscrape2.com", _str("TOSCRAPE2"))
+        assert reg.overrides_for(_r("http://toscrape.com/blabla")) == "TOSCRAPE"
+        assert reg.overrides_for(_r("http://toscrape2.com")) == "TOSCRAPE2"
+
+
+class TestPerDomainOverridesRegistry:
+
+    def test(self):
+        settings = {
+            "SCRAPY_POET_OVERRIDES": {
+                "toscrape.com": _str("TOSCRAPE")
+            }
+        }
+        crawler = get_crawler(Spider, settings)
+        reg = PerDomainOverridesRegistry.from_crawler(crawler)
+        assert reg.overrides_for(_r("http://toscrape.com/path")) == "TOSCRAPE"
+        assert reg.overrides_for(_r("http://books.toscrape.com/path")) == "TOSCRAPE"
+        assert reg.overrides_for(_r("http://toscrape2.com/path")) == {}


### PR DESCRIPTION
**Do not merge!**

An alternative to https://github.com/scrapinghub/scrapy-poet/pull/53

Existing rules as defined in the original requests are working. But now custom regexes can be used as well when required. The way they can be defined is by tuples containing the domain and a regex over the full URL. 

For example, consider the following configuration:
```py
OVERRIDES_1 = { ... }
OVERRIDES_2 = { ... }
{
"example.com/en_gb": OVERRIDES_1
("example.com", r"http://example.com/.*?product_id=[0-9]*.*): OVERRIDES_2
}
``` 
All URLs with `product_id` argument in the URL will go through `OVERRIDES_2`. Other URLs belonging to the subpath `en_gb` will go through `OVERRIDES_1`. 

This brings the best of the two words: using simple `domain_or_more` rules can still be used, and they will cover most of the cases. If something more powerful is required, then you can use regex. The fact that we are partitioning by `domain` makes also efficient enough this new approach. 

Note that in case of collusion of both rules  (for example for url http://example.com/en_gb/product?product_id=23 in the former example) those defined as regex has priority. And the priority over different regexes is defined by the order in which the regexes are declared. 

The priorities over the `domain_or_more` rules is defined according to the hierarchy (tld, domain, subdomain, path, etc), so the order in which they are defined is not affected. 

There is a possibility: enrich a bit more the `domain_or_more` rules by allowing globbing. For example, why not allow to declare rules like example.com/*product_id=*?. Implementation-wise it is not very hard to do. @kmike what do you think?

Note that we are here allowing registering default POs by using the empty string. Theoretically, you can also register regex for the empty domain and then they will be applied for any URL. But I don't think this is something we should promote, as it is not a good practice from the point of view of performance. 

TODO:

- [ ] Testing regex priorities 
- [ ] Documentation
- [ ] Separated registries per page object type
- [ ] globbing?
- [ ] Removing the old HierarchicalRegistry