### PR TITLE
SCRAPY_POET_CACHE mechanism

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+TBR:
+------------------
+
+* Cache mechanism using SCRAPY_POET_CACHE setting
+
 0.2.1 (2021-06-11)
 ------------------
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -26,6 +26,12 @@ Page Input Providers
 .. toctree::
    :hidden:
 
+Cache
+=====
+
+.. automodule:: scrapy_poet.cache
+   :members:
+
 Injection
 =========
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 scrapy-poet documentation
 =========================
 
-scrapy-poet allows to use `web-poet`_ Page Objects with Scrapy.
+``scrapy-poet`` allows to use `web-poet`_ Page Objects with Scrapy.
 
 web-poet_ defines a standard for writing reusable and portable
 extraction and crawling code; please check its docs_ to learn more.
@@ -48,6 +48,7 @@ To get started, see :ref:`intro-install` and :ref:`intro-tutorial`.
    :caption: All the rest
    :maxdepth: 1
 
+   settings
    api_reference
    contributing
    changelog

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -7,10 +7,10 @@ Installation
 Installing scrapy-poet
 ======================
 
-scrapy-poet is a Scrapy extension that runs on Python 3.7 and above.
+``scrapy-poet`` is a Scrapy extension that runs on Python 3.7 and above.
 
 If you’re already familiar with installation of Python packages, you can install
-scrapy-poet and its dependencies from PyPI with:
+``scrapy-poet`` and its dependencies from PyPI with:
 
 ::
 
@@ -21,7 +21,7 @@ Scrapy 2.1.0 or above is required and it has to be installed separately.
 Things that are good to know
 ============================
 
-scrapy-poet is written in pure Python and depends on a few key Python packages
+``scrapy-poet`` is written in pure Python and depends on a few key Python packages
 (among others):
 
 - web-poet_, core library used for Page Object pattern

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -4,7 +4,7 @@
 Tutorial
 ========
 
-In this tutorial, we’ll assume that scrapy-poet is already installed on your
+In this tutorial, we’ll assume that ``scrapy-poet`` is already installed on your
 system. If that’s not the case, see :ref:`intro-install`.
 
 .. note::
@@ -20,7 +20,7 @@ This tutorial will walk you through these tasks:
 
 #. Writing a :ref:`spider <scrapy:topics-spiders>` to crawl a site and extract data
 #. Separating extraction logic from the spider
-#. Configuring Scrapy project to use scrapy-poet
+#. Configuring Scrapy project to use ``scrapy-poet``
 #. Changing spider to make use of our extraction logic
 
 If you're not already familiar with Scrapy, and want to learn it quickly,
@@ -113,7 +113,7 @@ extract a property from the ``to_item`` method:
 Configuring the project
 =======================
 
-To use scrapy-poet, enable its downloader middleware in ``settings.py``:
+To use ``scrapy-poet``, enable its downloader middleware in ``settings.py``:
 
 .. code-block:: python
 
@@ -122,7 +122,7 @@ To use scrapy-poet, enable its downloader middleware in ``settings.py``:
     }
 
 
-``BookPage`` class we created previously can be used without scrapy-poet,
+``BookPage`` class we created previously can be used without ``scrapy-poet``,
 and even without Scrapy (note that imports were from ``web_poet`` so far).
 
 ``scrapy-poet`` makes it easy to use ``web-poet`` Page Objects
@@ -143,7 +143,7 @@ the ``parse_book`` method as follows:
             yield book_page.to_item()
 
 ``parse_book`` method now has a type annotated argument
-called ``book_page``. scrapy-poet detects this and makes sure
+called ``book_page``. ``scrapy-poet`` detects this and makes sure
 a BookPage instance is created and passed to the callback.
 
 The full spider code would be looking like this:
@@ -421,7 +421,7 @@ but it opens some cool possibilities.
 Next steps
 ==========
 
-Now that you know how scrapy-poet is supposed to work, what about trying to
+Now that you know how ``scrapy-poet`` is supposed to work, what about trying to
 apply it to an existing or new Scrapy project?
 
 Also, please check :ref:`overrides`, :ref:`providers` and refer to spiders in the "example"

--- a/docs/overrides.rst
+++ b/docs/overrides.rst
@@ -65,11 +65,12 @@ the obtained item with the ISBN from the page HTML.
 
 .. note::
 
-    This is an alternative more compact way of writing the above Page Object using ``attr.s``:
+    This is an alternative more compact way of writing the above Page Object
+    using ``attr.define``:
 
     .. code-block:: python
 
-        @attr.s(auto_attribs=True)
+        @attr.define
         class ISBNBookPage(ItemWebPage):
             book_page: BookPage
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,0 +1,80 @@
+.. _`settings`:
+
+Settings
+========
+
+Configuring the settings denoted below would follow the usual methods used by
+Scrapy.
+
+
+SCRAPY_POET_PROVIDERS
+---------------------
+
+Default: ``{}``
+
+A ``dict`` wherein the **keys** would be the providers available for your Scrapy
+project while the **values** denotes the priority of the provider.
+
+More info on this at this section: :ref:`providers`.
+
+
+SCRAPY_POET_OVERRIDES
+---------------------
+
+Default: ``None``
+
+Mapping of overrides for each domain. The format of the such ``dict`` mapping
+depends on the currently set Registry. The default is currently 
+:class:`~.PerDomainOverridesRegistry`. This can be overriden by the setting below:
+``SCRAPY_POET_OVERRIDES_REGISTRY``.
+
+There are sections dedicated for this at :ref:`intro-tutorial` and :ref:`overrides`.
+
+
+SCRAPY_POET_OVERRIDES_REGISTRY
+------------------------------
+
+Defaut: ``None``
+
+Sets an alternative Registry to replace the default :class:`~.PerDomainOverridesRegistry`.
+To use this, set a ``str`` which denotes the absolute object path of the new
+Registry.
+
+More info at :ref:`overrides`.
+
+
+SCRAPY_POET_CACHE
+-----------------
+
+Default: ``None``
+
+The caching mechanism in the **providers** can be enabled by either setting this
+to ``True`` which configures the file path of the cache into a ``.scrapy/`` dir
+in your `local Scrapy project`.
+
+On the other hand, you can also set this as a ``str`` pointing to any path relative
+to your `local Scrapy project`.
+
+
+SCRAPY_POET_CACHE_GZIP
+----------------------
+
+Default: ``True``
+
+Enables compression of the cached data using the **Gzip**. `Recommended` to be
+set to ``True`` in order to preserve disk space when caching.
+
+
+SCRAPY_POET_CACHE_ERRORS
+------------------------
+
+Default: ``False``
+
+When this is set to ``True``, any error that arises when retrieving dependencies from
+providers would be cached. This could be useful in cases during local development
+wherein you outright know that retrieving the dependency would fail and would
+choose to ignore it. Caching such errors would reduce the waiting time when
+developing Page Objects.
+
+It's `recommended` to set this off into ``False`` by default since you might miss
+out on sporadic errors.

--- a/scrapy_poet/__init__.py
+++ b/scrapy_poet/__init__.py
@@ -1,4 +1,7 @@
 from .middleware import InjectionMiddleware
 from .api import callback_for, DummyResponse
-from .page_input_providers import (PageObjectInputProvider,
-                                   ResponseDataProvider)
+from .page_input_providers import (
+    PageObjectInputProvider,
+    CacheDataProviderMixin,
+    ResponseDataProvider,
+)

--- a/scrapy_poet/cache.py
+++ b/scrapy_poet/cache.py
@@ -21,6 +21,10 @@ class _Cache(abc.ABC):
 
 
 class SqlitedictCache(_Cache):
+    """Stores dependencies from Providers in a persistent local storage using
+    https://github.com/RaRe-Technologies/sqlitedict.
+    """
+
     def __init__(self, path: str, *, compressed=True):
         self.path = path
         self.compressed = compressed

--- a/scrapy_poet/cache.py
+++ b/scrapy_poet/cache.py
@@ -1,0 +1,62 @@
+import abc
+import gzip
+import pickle
+import sqlite3
+
+import sqlitedict
+
+
+class _Cache(abc.ABC):
+
+    @abc.abstractmethod
+    def __getitem__(self, fingerprint: str):
+        pass
+
+    @abc.abstractmethod
+    def __setitem__(self, fingerprint: str, value) -> None:
+        pass
+
+    def close(self):
+        pass
+
+
+class SqlitedictCache(_Cache):
+
+    def __init__(self, path, *, compressed=True):
+        self.compressed = compressed
+        tablename = 'responses_gzip' if compressed else 'responses'
+        self.db = sqlitedict.SqliteDict(path,
+                                        tablename=tablename,
+                                        autocommit=True,
+                                        encode=self.encode,
+                                        decode=self.decode)
+
+    def encode(self, obj):
+        # based on sqlitedict.encode
+        data = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
+        if self.compressed:
+            data = gzip.compress(data, compresslevel=3)
+        return sqlite3.Binary(data)
+
+    def decode(self, obj):
+        # based on sqlitedict.decode
+        data = bytes(obj)
+        if self.compressed:
+            # gzip is slightly less efficient than raw zlib, but it does
+            # e.g. crc checks out of box
+            data = gzip.decompress(data)
+        return pickle.loads(data)
+
+    def __str__(self):
+        return f"SqlitedictCache <{self.db.filename} | " \
+               f"compressed: {self.compressed} | " \
+               f"{len(self.db)} records>"
+
+    def __getitem__(self, fingerprint: str):
+        return self.db[fingerprint]
+
+    def __setitem__(self, fingerprint: str, value) -> None:
+        self.db[fingerprint] = value
+
+    def close(self):
+        self.db.close()

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -66,6 +66,10 @@ class Injector:
         self.is_class_provided_by_any_provider = \
             is_class_provided_by_any_provider_fn(self.providers)
 
+    def close(self) -> None:
+        if self.cache:
+            self.cache.close()
+
     def init_cache(self):
         self.cache = None
         cache_filename = self.spider.settings.get('SCRAPY_POET_CACHE')
@@ -361,7 +365,7 @@ def get_response_for_testing(callback: Callable) -> Response:
         <html>
             <body>
                 <div class="breadcrumbs">
-                    <a href="/food">Food</a> / 
+                    <a href="/food">Food</a> /
                     <a href="/food/sweets">Sweets</a>
                 </div>
                 <h1 class="name">Chocolate</h1>

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -77,7 +77,7 @@ class Injector:
             cache_filename = os.path.join(get_scrapy_data_path(createdir=True), "scrapy-poet-cache.sqlite3")
         if cache_filename:
             compressed = self.spider.settings.getbool('SCRAPY_POET_CACHE_GZIP', True)
-            self.caching_errors = self.spider.settings.getbool('SCRAPY_POET_CACHE_ALSO_ERRORS', False)
+            self.caching_errors = self.spider.settings.getbool('SCRAPY_POET_CACHE_ERRORS', False)
             self.cache = SqlitedictCache(cache_filename, compressed=compressed)
             logger.info(f"Cache enabled. File: '{cache_filename}'. Compressed: {compressed}. Caching errors: {self.caching_errors}")
 

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -164,7 +164,7 @@ class Injector:
 
             objs, fingerprint = None, None
             cache_hit = False
-            if self.cache:
+            if self.cache and provider.has_cache_support:
                 if not provider.name:
                     raise NotImplementedError(f"The provider {type(provider)} must have a `name` defined if"
                                               f" you want to use the cache. It must be unique across the providers.")
@@ -194,7 +194,7 @@ class Injector:
                     objs = yield maybeDeferred_coro(provider, set(provided_classes), **kwargs)
 
                 except Exception as e:
-                    if self.cache and self.caching_errors:
+                    if self.cache and self.caching_errors and provider.has_cache_support:
                         # Save errors in the cache
                         self.cache[fingerprint] = e
                         self.crawler.stats.inc_value("scrapy-poet/cache/firsthand")
@@ -210,7 +210,7 @@ class Injector:
                 )
             instances.update(objs_by_type)
 
-            if self.cache and not cache_hit:
+            if self.cache and not cache_hit and provider.has_cache_support:
                 # Save the results in the cache
                 self.cache[fingerprint] = provider.serialize(objs)
                 self.crawler.stats.inc_value("scrapy-poet/cache/firsthand")

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -176,7 +176,7 @@ class Injector:
                     self.crawler.stats.inc_value("scrapy-poet/cache/miss")
                 else:
                     self.crawler.stats.inc_value("scrapy-poet/cache/hit")
-                    if isinstance(data, BaseException):
+                    if isinstance(data, Exception):
                         raise data
                     objs = provider.deserialize(data)
                     cache_hit = True
@@ -193,7 +193,7 @@ class Injector:
                     # Invoke the provider to get the data
                     objs = yield maybeDeferred_coro(provider, set(provided_classes), **kwargs)
 
-                except BaseException as e:
+                except Exception as e:
                     if self.cache and self.caching_errors:
                         # Save errors in the cache
                         self.cache[fingerprint] = e

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -1,3 +1,6 @@
+import os
+
+from scrapy.utils.project import project_data_dir, inside_project
 from tldextract import tldextract
 
 
@@ -13,3 +16,15 @@ def get_domain(url):
     'example.co.uk'
     """
     return ".".join(tldextract.extract(url)[-2:])
+
+
+def get_scrapy_data_path(createdir=True):
+    """ Return a path to a folder where Scrapy is storing data.
+    Usually that's a .scrapy folder inside the project.
+    """
+    # This code is extracted from scrapy.utils.project.data_path function,
+    # which does too many things.
+    path = project_data_dir() if inside_project() else ".scrapy"
+    if createdir:
+        os.makedirs(path, exist_ok=True)
+    return path

--- a/scrapy_poet/utils.py
+++ b/scrapy_poet/utils.py
@@ -18,13 +18,13 @@ def get_domain(url):
     return ".".join(tldextract.extract(url)[-2:])
 
 
-def get_scrapy_data_path(createdir=True):
-    """ Return a path to a folder where Scrapy is storing data.
+def get_scrapy_data_path(createdir: bool = True, default_dir: str = ".scrapy") -> str:
+    """Return a path to a folder where Scrapy is storing data.
     Usually that's a .scrapy folder inside the project.
     """
     # This code is extracted from scrapy.utils.project.data_path function,
     # which does too many things.
-    path = project_data_dir() if inside_project() else ".scrapy"
+    path = project_data_dir() if inside_project() else default_dir
     if createdir:
         os.makedirs(path, exist_ok=True)
     return path

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ setup(
         'attrs',
         'parsel',
         'web-poet',
-        'tldextract'],
+        'tldextract',
+        'sqlitedict',
+    ],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -9,7 +9,7 @@ from scrapy import Request
 from scrapy.http import Response
 from scrapy_poet.utils import get_domain
 
-from scrapy_poet import ResponseDataProvider, PageObjectInputProvider, \
+from scrapy_poet import CacheDataProviderMixin, ResponseDataProvider, PageObjectInputProvider, \
     DummyResponse
 from scrapy_poet.injection import check_all_providers_are_callable, is_class_provided_by_any_provider_fn, \
     get_injector_for_testing, get_response_for_testing
@@ -371,7 +371,7 @@ def test_is_class_provided_by_any_provider_fn():
 
 
 def get_provider_for_cache(classes, a_name, content=None, error=ValueError):
-    class Provider(PageObjectInputProvider):
+    class Provider(PageObjectInputProvider, CacheDataProviderMixin):
         name = a_name
         provided_classes = classes
         require_response = False

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -420,7 +420,7 @@ def test_cache(tmp_path, cache_errors):
         print(f"Cache file {cache} already exists. Weird. Deleting")
         cache.unlink()
     settings = {"SCRAPY_POET_CACHE": cache,
-                "SCRAPY_POET_CACHE_ALSO_ERRORS": cache_errors}
+                "SCRAPY_POET_CACHE_ERRORS": cache_errors}
     injector = get_injector_for_testing(providers, settings)
     assert cache.exists()
 

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,3 +1,5 @@
+from typing import Any, Sequence, Set, Callable
+
 import attr
 import pytest
 from pytest_twisted import inlineCallbacks
@@ -5,6 +7,8 @@ import weakref
 
 from scrapy import Request
 from scrapy.http import Response
+from scrapy_poet.utils import get_domain
+
 from scrapy_poet import ResponseDataProvider, PageObjectInputProvider, \
     DummyResponse
 from scrapy_poet.injection import check_all_providers_are_callable, is_class_provided_by_any_provider_fn, \
@@ -364,3 +368,94 @@ def test_is_class_provided_by_any_provider_fn():
 
     with pytest.raises(InjectionError):
         is_class_provided_by_any_provider_fn([WrongProvider])
+
+
+def get_provider_for_cache(classes, a_name, content=None, error=ValueError):
+    class Provider(PageObjectInputProvider):
+        name = a_name
+        provided_classes = classes
+        require_response = False
+
+        def __init__(self, crawler):
+            self.crawler = crawler
+
+        def __call__(self, to_provide, request: Request):
+            if not get_domain(request.url) == "example.com":
+                raise error("The URL is not from example.com")
+            return [cls(content) if content else cls() for cls in classes]
+
+        def fingerprint(self, to_provide: Set[Callable], request: Request) -> str:
+            return request.url
+
+        def serialize(self, result: Sequence[Any]) -> Any:
+            return result
+
+        def deserialize(self, data: Any) -> Sequence[Any]:
+            return data
+
+    return Provider
+
+
+@pytest.mark.parametrize("cache_errors", [True, False])
+@inlineCallbacks
+def test_cache(tmp_path, cache_errors):
+    """
+    In a first run, the cache is empty, and two requests are done, one with exception.
+    In the second run we should get the same result as in the first run. The
+    behaviour for exceptions vary if caching errors is disabled.
+    """
+    providers = {
+                    get_provider_for_cache({str}, "str", content="foo"): 1,
+                    get_provider_for_cache({int, float}, "number", content=3): 2,
+                 }
+
+    cache = tmp_path / "cache3.sqlite3"
+    if cache.exists():
+        print(f"Cache file {cache} already exists. Weird. Deleting")
+        cache.unlink()
+    settings = {"SCRAPY_POET_CACHE": cache,
+                "SCRAPY_POET_CACHE_ALSO_ERRORS": cache_errors}
+    injector = get_injector_for_testing(providers, settings)
+    assert cache.exists()
+
+    def callback(response: DummyResponse, arg_str: str, arg_int: int, arg_float: float):
+        pass
+
+    response = get_response_for_testing(callback)
+    plan = injector.build_plan(response.request)
+    instances = yield from injector.build_instances_from_providers(
+        response.request, response, plan)
+
+    assert instances[str] == "foo"
+    assert instances[int] == 3
+    assert instances[float] == 3.0
+
+    response.request = Request.replace(response.request, url="http://willfail.page")
+    with pytest.raises(ValueError):
+        plan = injector.build_plan(response.request)
+        instances = yield from injector.build_instances_from_providers(
+            response.request, response, plan)
+
+    # Different providers. They return a different result, but the cache data should prevail.
+    providers = {
+                    get_provider_for_cache({str}, "str", content="bar", error=KeyError): 1,
+                    get_provider_for_cache({int, float}, "number", content=4, error=KeyError): 2,
+                 }
+    injector = get_injector_for_testing(providers, settings)
+
+    response = get_response_for_testing(callback)
+    plan = injector.build_plan(response.request)
+    instances = yield from injector.build_instances_from_providers(
+        response.request, response, plan)
+
+    assert instances[str] == "foo"
+    assert instances[int] == 3
+    assert instances[float] == 3.0
+
+    # If caching errors is disabled, then KeyError should be raised.
+    Error = ValueError if cache_errors else KeyError
+    response.request = Request.replace(response.request, url="http://willfail.page")
+    with pytest.raises(Error):
+        plan = injector.build_plan(response.request)
+        instances = yield from injector.build_instances_from_providers(
+            response.request, response, plan)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,18 +3,22 @@ import socket
 from scrapy.utils.log import configure_logging
 from twisted.internet.threads import deferToThread
 from typing import Optional, Union, Type
+from unittest import mock
 
 import pytest
 import scrapy
-from scrapy import Request
+from scrapy import Request, Spider
 from scrapy.http import Response
+from scrapy.utils.test import get_crawler
 from pytest_twisted import inlineCallbacks
 
 import attr
 
 from scrapy_poet import callback_for
+from scrapy_poet import InjectionMiddleware
 from scrapy_poet.utils import get_domain
 from web_poet.pages import WebPage, ItemPage, ItemWebPage
+from scrapy_poet.cache import SqlitedictCache
 from scrapy_poet.page_input_providers import (
     PageObjectInputProvider
 )
@@ -30,7 +34,7 @@ class ProductHtml(HtmlResource):
     html = """
     <html>
         <div class="breadcrumbs">
-            <a href="/food">Food</a> / 
+            <a href="/food">Food</a> /
             <a href="/food/sweets">Sweets</a>
         </div>
         <h1 class="name">Chocolate</h1>
@@ -316,3 +320,29 @@ def test_skip_downloads(settings):
     assert isinstance(item['response'], DummyResponse) is True
     assert crawler.stats.get_stats().get('downloader/request_count', 0) == 0
     assert crawler.stats.get_stats().get('downloader/response_count', 0) == 1
+
+
+@mock.patch("scrapy_poet.injection.SqlitedictCache", spec=SqlitedictCache)
+def test_cache_closed_on_spider_close(mock_sqlitedictcache, settings):
+    def get_middleware(settings):
+        crawler = get_crawler(Spider, settings)
+        crawler.spider = crawler._create_spider('example.com')
+        return InjectionMiddleware(crawler)
+
+    mock_sqlitedictcache_instance = mock_sqlitedictcache.return_value = mock.Mock()
+
+    # no cache
+    no_cache_middleware = get_middleware(settings)
+    assert no_cache_middleware.injector.cache is None
+
+    # cache is present
+    settings.set("SCRAPY_POET_CACHE", "/tmp/cache")
+    has_cache_middleware = get_middleware(settings)
+    assert has_cache_middleware.injector.cache is not None
+
+    spider = has_cache_middleware.crawler.spider
+    has_cache_middleware.spider_closed(spider)
+    assert mock_sqlitedictcache.mock_calls == [
+        mock.call('/tmp/cache', compressed=True),
+        mock.call().close()
+    ]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,7 +1,9 @@
-from typing import Any, List
+import dataclasses
+from typing import Any, List, Set, Callable, Sequence
 
 import attr
 from pytest_twisted import inlineCallbacks
+from scrapy_poet import ResponseDataProvider
 from twisted.python.failure import Failure
 
 import scrapy
@@ -10,6 +12,7 @@ from scrapy.crawler import Crawler
 from scrapy.settings import Settings
 from scrapy_poet.page_input_providers import PageObjectInputProvider
 from tests.utils import crawl_single_item, HtmlResource
+from web_poet import ResponseData
 
 
 class ProductHtml(HtmlResource):
@@ -22,6 +25,13 @@ class ProductHtml(HtmlResource):
         <h1 class="name">Chocolate</h1>
         <p>Price: <span class="price">22€</span></p>
         <p class="description">The best chocolate ever</p>
+    </html>
+    """
+
+class NonProductHtml(HtmlResource):
+    html = """
+    <html>
+        <p>This one is clearly not a product</p>
     </html>
     """
 
@@ -43,6 +53,7 @@ class Html:
 
 class PriceHtmlDataProvider(PageObjectInputProvider):
 
+    name = "price_html"
     provided_classes = {Price, Html}
 
     def __init__(self, crawler: Crawler):
@@ -58,9 +69,19 @@ class PriceHtmlDataProvider(PageObjectInputProvider):
             ret.append(Html("Price Html!"))
         return ret
 
+    def fingerprint(self, to_provide: Set[Callable], request: Request) -> str:
+        return "http://example.com"
+
+    def serialize(self, result: Sequence[Any]) -> Any:
+        return result
+
+    def deserialize(self, data: Any) -> Sequence[Any]:
+        return data
+
 
 class NameHtmlDataProvider(PageObjectInputProvider):
 
+    name = "name_html"
     provided_classes = {Name, Html}.__contains__
 
     def __call__(self, to_provide, response: scrapy.http.Response, settings: Settings):
@@ -72,12 +93,29 @@ class NameHtmlDataProvider(PageObjectInputProvider):
             ret.append(Html("Name Html!"))
         return ret
 
+    def fingerprint(self, to_provide: Set[Callable], request: Request) -> str:
+        return "http://example.com"
+
+    def serialize(self, result: Sequence[Any]) -> Any:
+        return result
+
+    def deserialize(self, data: Any) -> Sequence[Any]:
+        return data
+
+
+class ResponseDataProviderForTest(ResponseDataProvider):
+    """Uses a fixed fingerprint because the test server is always changing the URL from test to test"""
+
+    def fingerprint(self, to_provide: Set[Callable], request: Request) -> str:
+        return "http://example.com"
+
 
 class PriceFirstMultiProviderSpider(scrapy.Spider):
 
     url = None
     custom_settings = {
         "SCRAPY_POET_PROVIDERS": {
+            ResponseDataProviderForTest: 0,
             PriceHtmlDataProvider: 1,
             NameHtmlDataProvider: 2,
         }
@@ -89,11 +127,12 @@ class PriceFirstMultiProviderSpider(scrapy.Spider):
     def errback(self, failure: Failure):
         yield {"exception": failure.value}
 
-    def parse(self, response, price: Price, name: Name, html: Html):
+    def parse(self, response, price: Price, name: Name, html: Html, response_data: ResponseData):
         yield {
             Price: price,
             Name: name,
-            Html: html
+            Html: html,
+            "response_data_html": response_data.html,
         }
 
 
@@ -101,6 +140,7 @@ class NameFirstMultiProviderSpider(PriceFirstMultiProviderSpider):
 
     custom_settings = {
         "SCRAPY_POET_PROVIDERS": {
+            ResponseDataProviderForTest: 0,
             NameHtmlDataProvider: 1,
             PriceHtmlDataProvider: 2,
         }
@@ -108,14 +148,30 @@ class NameFirstMultiProviderSpider(PriceFirstMultiProviderSpider):
 
 
 @inlineCallbacks
-def test_name_first_spider(settings):
+def test_name_first_spider(settings, tmp_path):
+    cache = tmp_path / "cache.sqlite3"
+    settings.set("SCRAPY_POET_CACHE", str(cache))
     item, _, _ = yield crawl_single_item(NameFirstMultiProviderSpider, ProductHtml,
+                                         settings)
+    assert cache.exists()
+    assert item == {
+        Price: Price("22€"),
+        Name: Name("Chocolate"),
+        Html: Html("Name Html!"),
+        "response_data_html": ProductHtml.html,
+    }
+
+    # Let's see that the cache is working. We use a different and wrong resource,
+    # but it should be ignored by the cached version used
+    item, _, _ = yield crawl_single_item(NameFirstMultiProviderSpider, NonProductHtml,
                                          settings)
     assert item == {
         Price: Price("22€"),
         Name: Name("Chocolate"),
         Html: Html("Name Html!"),
+        "response_data_html": ProductHtml.html,
     }
+
 
 
 @inlineCallbacks
@@ -126,4 +182,5 @@ def test_price_first_spider(settings):
         Price: Price("22€"),
         Name: Name("Chocolate"),
         Html: Html("Price Html!"),
+        "response_data_html": ProductHtml.html,
     }

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,7 +11,7 @@ from scrapy import Request, Spider
 from scrapy.crawler import Crawler
 from scrapy.settings import Settings
 from scrapy.utils.test import get_crawler
-from scrapy_poet.page_input_providers import PageObjectInputProvider
+from scrapy_poet.page_input_providers import CacheDataProviderMixin, PageObjectInputProvider
 from tests.utils import crawl_single_item, HtmlResource
 from web_poet import ResponseData
 
@@ -52,7 +52,7 @@ class Html:
     html: str
 
 
-class PriceHtmlDataProvider(PageObjectInputProvider):
+class PriceHtmlDataProvider(PageObjectInputProvider, CacheDataProviderMixin):
 
     name = "price_html"
     provided_classes = {Price, Html}
@@ -80,7 +80,7 @@ class PriceHtmlDataProvider(PageObjectInputProvider):
         return data
 
 
-class NameHtmlDataProvider(PageObjectInputProvider):
+class NameHtmlDataProvider(PageObjectInputProvider, CacheDataProviderMixin):
 
     name = "name_html"
     provided_classes = {Name, Html}.__contains__

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, List, Set, Callable, Sequence
 
 import attr

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,14 +1,16 @@
 from typing import Any, List, Set, Callable, Sequence
 
 import attr
+import json
 from pytest_twisted import inlineCallbacks
 from scrapy_poet import ResponseDataProvider
 from twisted.python.failure import Failure
 
 import scrapy
-from scrapy import Request
+from scrapy import Request, Spider
 from scrapy.crawler import Crawler
 from scrapy.settings import Settings
+from scrapy.utils.test import get_crawler
 from scrapy_poet.page_input_providers import PageObjectInputProvider
 from tests.utils import crawl_single_item, HtmlResource
 from web_poet import ResponseData
@@ -18,7 +20,7 @@ class ProductHtml(HtmlResource):
     html = """
     <html>
         <div class="breadcrumbs">
-            <a href="/food">Food</a> / 
+            <a href="/food">Food</a> /
             <a href="/food/sweets">Sweets</a>
         </div>
         <h1 class="name">Chocolate</h1>
@@ -183,3 +185,13 @@ def test_price_first_spider(settings):
         Html: Html("Price Html!"),
         "response_data_html": ProductHtml.html,
     }
+
+
+def test_response_data_provider_fingerprint(settings):
+    crawler = get_crawler(Spider, settings)
+    rdp = ResponseDataProvider(crawler)
+    request = scrapy.http.Request("https://example.com")
+
+    # The fingerprint should be readable since it's JSON-encoded.
+    fp = rdp.fingerprint(scrapy.http.Response, request)
+    assert json.loads(fp)


### PR DESCRIPTION
New providers interface

Error caching can be enabled or disabled.

Compression can be enabled or disabled.

Avoiding having key conflicts between provides was done by adding prefix to each key. It would be more efficient to have a separate table per provider in the sqlite database. I leave this for the future.

Todo:

- [x] FIx tox py36. It seems to get stuck
- [ ] Improve test coverage
- [ ] Documentation

**Possible documentation schema**:

It can be a new section "Cache" in the `ADVANCED` section. 

1.  What is the cache
2. A simple example enabling the cache
3. Cache configuration
3.1 Simple mode (setting it to TRUE)
3.2 Custom cache file (setting a custom file for the cache)
3.3 GZIP compression enable/disable (enabled by default)
3.4. Cache errors. Why. Disabled by default.

The "Providers" section should be updated. It should include:

* How to create providers that can be cached: they must have a name and implement the methods `fingerprint`, `serialize`, `deserialize`
* Explain that cache is important if we want the `scrapy override` command to work
* Explain how these methods behave and how should they be implemented
* Show examples