### PR TITLE
docs: fix broken link to `parsel`

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -30,4 +30,4 @@ Things that are good to know
 
 .. _web-poet: https://github.com/scrapinghub/web-poet
 .. _andi: https://github.com/scrapinghub/andi
-.. _parsel: https://github.com/scrapinghub/parsel
+.. _parsel: https://github.com/scrapy/parsel


### PR DESCRIPTION
The page https://github.com/scrapinghub/parsel does not exist.

This PR fixes the link to https://github.com/scrapy/parsel.