### PR TITLE
Use the new HttpResponse that replaces ResponseData in web_poet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+TBR
+---
+
+* Use the new ``web_poet.HttpResponse`` which replaces ``web_poet.ResponseData``.
+
 
 0.3.0 (2022-01-28)
 ------------------

--- a/docs/overrides.rst
+++ b/docs/overrides.rst
@@ -34,7 +34,7 @@ using the following Page Object:
 
     class ISBNBookPage(ItemWebPage):
 
-        def __init__(self, response: ResponseData, book_page: BookPage):
+        def __init__(self, response: HttpResponse, book_page: BookPage):
             super().__init__(response)
             self.book_page = book_page
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -40,8 +40,14 @@ that need it, like the ``web_poet.ItemWebPage``.
 
         def __call__(self, to_provide: Set[Callable], response: Response):
             """Build a ``web_poet.HttpResponse`` instance using a Scrapy ``Response``"""
-            return [web_poet.HttpResponse(url=response.url, body=response.body)]
-
+            return [
+                HttpResponse(
+                    url=response.url,
+                    body=response.body,
+                    status=response.status,
+                    headers=web_poet.HttpResponseHeaders.from_bytes(response.headers),
+                )
+            ]
 
 You can implement your own providers in order to extend or override current
 ``scrapy-poet`` behavior. All providers should inherit from this base class:
@@ -76,7 +82,14 @@ would lead to the following code:
 
         def __call__(self, to_provide: Set[Callable], response: Response):
             """Build a ``web_poet.HttpResponse`` instance using a Scrapy ``Response``"""
-            return [web_poet.HttpResponse(url=response.url, body=response.body)]
+            return [
+                HttpResponse(
+                    url=response.url,
+                    body=response.body,
+                    status=response.status,
+                    headers=web_poet.HttpResponseHeaders.from_bytes(response.headers),
+                )
+            ]
 
         def fingerprint(self, to_provide: Set[Callable], request: Request) -> str:
             """Returns a fingerprint to identify the specific request."""

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -20,33 +20,27 @@ Creating providers
 ==================
 
 Providers are responsible for building dependencies needed by Injectable
-objects. A good example would be the ``ResponseDataProvider``,
-which builds and provides a ``ResponseData`` instance for Injectables
-that need it, like the ``ItemWebPage``.
+objects. A good example would be the ``HttpResponseProvider``,
+which builds and provides a ``web_poet.HttpResponse`` instance for Injectables
+that need it, like the ``web_poet.ItemWebPage``.
 
 .. code-block:: python
 
     import attr
     from typing import Set, Callable
 
+    import web_poet
     from scrapy_poet.page_input_providers import PageObjectInputProvider
     from scrapy import Response
 
 
-    @attr.define
-    class ResponseData:
-        """Represents a response containing its URL and HTML content."""
-        url: str
-        html: str
-
-
-    class ResponseDataProvider(PageObjectInputProvider):
-        """This class provides ``web_poet.page_inputs.ResponseData`` instances."""
-        provided_classes = {ResponseData}
+    class HttpResponseProvider(PageObjectInputProvider):
+        """This class provides ``web_poet.HttpResponse`` instances."""
+        provided_classes = {web_poet.HttpResponse}
 
         def __call__(self, to_provide: Set[Callable], response: Response):
-            """Build a ``ResponseData`` instance using a Scrapy ``Response``"""
-            return [ResponseData(url=response.url, html=response.text)]
+            """Build a ``web_poet.HttpResponse`` instance using a Scrapy ``Response``"""
+            return [web_poet.HttpResponse(url=response.url, body=response.body)]
 
 
 You can implement your own providers in order to extend or override current
@@ -61,7 +55,7 @@ Cache Suppport in Providers
 ===========================
 
 ``scrapy-poet`` also supports caching of the provided dependencies from the
-providers. For example, :class:`~.ResponseDataProvider` supports this right off
+providers. For example, :class:`~.HttpResponseProvider` supports this right off
 the bat. It's able to do this by inheriting the :class:`~.CacheDataProviderMixin`
 and implementing all of its ``abstractmethods``.
 
@@ -70,18 +64,19 @@ would lead to the following code:
 
 .. code-block:: python
 
+    import web_poet
     from scrapy_poet.page_input_providers import (
         CacheDataProviderMixin,
         PageObjectInputProvider,
     )
 
-    class ResponseDataProvider(PageObjectInputProvider, CacheDataProviderMixin):
-        """This class provides ``web_poet.page_inputs.ResponseData`` instances."""
-        provided_classes = {ResponseData}
+    class HttpResponseProvider(PageObjectInputProvider, CacheDataProviderMixin):
+        """This class provides ``web_poet.HttpResponse`` instances."""
+        provided_classes = {web_poet.HttpResponse}
 
         def __call__(self, to_provide: Set[Callable], response: Response):
-            """Build a ``ResponseData`` instance using a Scrapy ``Response``"""
-            return [ResponseData(url=response.url, html=response.text)]
+            """Build a ``web_poet.HttpResponse`` instance using a Scrapy ``Response``"""
+            return [web_poet.HttpResponse(url=response.url, body=response.body)]
 
         def fingerprint(self, to_provide: Set[Callable], request: Request) -> str:
             """Returns a fingerprint to identify the specific request."""
@@ -136,7 +131,7 @@ configuration dictionaries for more information.
 .. note::
 
     The providers in :const:`scrapy_poet.DEFAULT_PROVIDERS`,
-    which includes a provider for :class:`~ResponseData`, are always
+    which includes a provider for :class:`~HttpResponse`, are always
     included by default. You can disable any of them by listing it
     in the configuration with the priority `None`.
 
@@ -264,8 +259,8 @@ Page Object uses it, the request is not ignored, for example:
 
     The code above is just for example purposes. If you need to use ``Response``
     instances in your Page Objects, use built-in ``ItemWebPage`` - it has
-    ``response`` attribute with ``ResponseData``; no additional configuration
-    is needed, as there is ``ResponseDataProvider`` enabled in ``scrapy-poet``
+    ``response`` attribute with ``HttpResponse``; no additional configuration
+    is needed, as there is ``HttpResponseProvider`` enabled in ``scrapy-poet``
     by default.
 
 Requests concurrency

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -45,7 +45,7 @@ that need it, like the ``web_poet.ItemWebPage``.
                     url=response.url,
                     body=response.body,
                     status=response.status,
-                    headers=web_poet.HttpResponseHeaders.from_bytes(response.headers),
+                    headers=web_poet.HttpResponseHeaders.from_bytes_dict(response.headers),
                 )
             ]
 
@@ -87,7 +87,7 @@ would lead to the following code:
                     url=response.url,
                     body=response.body,
                     status=response.status,
-                    headers=web_poet.HttpResponseHeaders.from_bytes(response.headers),
+                    headers=web_poet.HttpResponseHeaders.from_bytes_dict(response.headers),
                 )
             ]
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -83,7 +83,7 @@ would lead to the following code:
         def __call__(self, to_provide: Set[Callable], response: Response):
             """Build a ``web_poet.HttpResponse`` instance using a Scrapy ``Response``"""
             return [
-                HttpResponse(
+                web_poet.HttpResponse(
                     url=response.url,
                     body=response.body,
                     status=response.status,

--- a/scrapy_poet/__init__.py
+++ b/scrapy_poet/__init__.py
@@ -3,5 +3,5 @@ from .api import callback_for, DummyResponse
 from .page_input_providers import (
     PageObjectInputProvider,
     CacheDataProviderMixin,
-    ResponseDataProvider,
+    HttpResponseProvider,
 )

--- a/scrapy_poet/middleware.py
+++ b/scrapy_poet/middleware.py
@@ -13,7 +13,7 @@ from twisted.internet.defer import inlineCallbacks
 from scrapy.utils.misc import create_instance, load_object
 from .api import DummyResponse
 from .overrides import PerDomainOverridesRegistry
-from .page_input_providers import ResponseDataProvider
+from .page_input_providers import HttpResponseProvider
 from .injection import Injector
 
 
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_PROVIDERS = {
-    ResponseDataProvider: 500
+    HttpResponseProvider: 500
 }
 
 InjectionMiddlewareTV = TypeVar("InjectionMiddlewareTV", bound="InjectionMiddleware")

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -167,7 +167,7 @@ class HttpResponseProvider(PageObjectInputProvider, CacheDataProviderMixin):
                 url=response.url,
                 body=response.body,
                 status=response.status,
-                headers=HttpResponseHeaders.from_bytes(response.headers),
+                headers=HttpResponseHeaders.from_bytes_dict(response.headers),
             )
         ]
 
@@ -192,9 +192,9 @@ class HttpResponseProvider(PageObjectInputProvider, CacheDataProviderMixin):
             HttpResponse(
                 response_data["url"],
                 response_data["body"],
-                response_data["status"],
-                HttpResponseHeaders.from_bytes(response_data["headers"]),
-                response_data["_encoding"],
+                status=response_data["status"],
+                headers=HttpResponseHeaders.from_bytes_dict(response_data["headers"]),
+                encoding=response_data["_encoding"],
             )
             for response_data in data
         ]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'andi >= 0.4.1',
         'attrs',
         'parsel',
-        'web-poet',
+        'web-poet @ git+https://git@github.com/scrapinghub/web-poet@master#egg=web-poet',
         'tldextract',
         'sqlitedict',
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'andi >= 0.4.1',
         'attrs',
         'parsel',
-        'web-poet @ git+https://git@github.com/scrapinghub/web-poet@master#egg=web-poet',
+        'web-poet @ git+https://git@github.com/scrapinghub/web-poet@from_bytes#egg=web-poet',
         'tldextract',
         'sqlitedict',
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'andi >= 0.4.1',
         'attrs',
         'parsel',
-        'web-poet @ git+https://git@github.com/scrapinghub/web-poet@from_bytes#egg=web-poet',
+        'web-poet @ git+https://git@github.com/scrapinghub/web-poet@master#egg=web-poet',
         'tldextract',
         'sqlitedict',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from scrapy.settings import Settings
 
-from scrapy_poet.page_input_providers import ResponseDataProvider
+from scrapy_poet.page_input_providers import HttpResponseProvider
 
 
 @pytest.fixture()

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -5,11 +5,12 @@ import pytest
 from pytest_twisted import inlineCallbacks
 import weakref
 
+import parsel
 from scrapy import Request
 from scrapy.http import Response
 from scrapy_poet.utils import get_domain
 
-from scrapy_poet import CacheDataProviderMixin, ResponseDataProvider, PageObjectInputProvider, \
+from scrapy_poet import CacheDataProviderMixin, HttpResponseProvider, PageObjectInputProvider, \
     DummyResponse
 from scrapy_poet.injection import check_all_providers_are_callable, is_class_provided_by_any_provider_fn, \
     get_injector_for_testing, get_response_for_testing
@@ -264,6 +265,10 @@ class Html(Injectable):
     url = "http://example.com"
     html = """<html><body>Price: <span class="price">22</span>€</body></html>"""
 
+    @property
+    def selector(self):
+        return parsel.Selector(self.html)
+
 
 class EurDollarRate(Injectable):
     rate = 1.1
@@ -332,17 +337,17 @@ class TestInjectorOverrides:
 
 
 def test_load_provider_classes():
-    provider_as_string = f"{ResponseDataProvider.__module__}.{ResponseDataProvider.__name__}"
-    injector = get_injector_for_testing({provider_as_string: 2, ResponseDataProvider: 1})
-    assert all(type(prov) == ResponseDataProvider for prov in injector.providers)
+    provider_as_string = f"{HttpResponseProvider.__module__}.{HttpResponseProvider.__name__}"
+    injector = get_injector_for_testing({provider_as_string: 2, HttpResponseProvider: 1})
+    assert all(type(prov) == HttpResponseProvider for prov in injector.providers)
     assert len(injector.providers) == 2
 
 
 def test_check_all_providers_are_callable():
-    check_all_providers_are_callable([ResponseDataProvider(None)])
+    check_all_providers_are_callable([HttpResponseProvider(None)])
     with pytest.raises(NonCallableProviderError) as exinf:
         check_all_providers_are_callable([PageObjectInputProvider(None),
-                                          ResponseDataProvider(None)])
+                                          HttpResponseProvider(None)])
 
     assert "PageObjectInputProvider" in str(exinf.value)
     assert "not callable" in str(exinf.value)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -22,7 +22,7 @@ from scrapy_poet.cache import SqlitedictCache
 from scrapy_poet.page_input_providers import (
     PageObjectInputProvider
 )
-from web_poet.page_inputs import ResponseData
+from web_poet.page_inputs import HttpResponse
 from scrapy_poet import DummyResponse
 from tests.utils import (HtmlResource,
                          crawl_items,
@@ -125,10 +125,10 @@ class OptionalAndUnionPage(ItemWebPage):
     breadcrumbs: BreadcrumbsExtraction
     opt_check_1: Optional[BreadcrumbsExtraction]
     opt_check_2: Optional[str]  # str is not Injectable, so None expected here
-    union_check_1: Union[BreadcrumbsExtraction, ResponseData]  # Breadcrumbs is injected
-    union_check_2: Union[str, ResponseData]  # ResponseData is injected
-    union_check_3: Union[Optional[str], ResponseData]  # None is injected
-    union_check_4: Union[None, str, ResponseData]  # None is injected
+    union_check_1: Union[BreadcrumbsExtraction, HttpResponse]  # Breadcrumbs is injected
+    union_check_2: Union[str, HttpResponse]  # HttpResponse is injected
+    union_check_3: Union[Optional[str], HttpResponse]  # None is injected
+    union_check_4: Union[None, str, HttpResponse]  # None is injected
     union_check_5: Union[BreadcrumbsExtraction, None, str]  # Breadcrumbs is injected
 
     def to_item(self):
@@ -151,7 +151,7 @@ def test_optional_and_unions(settings):
 @attr.s(auto_attribs=True)
 class ProvidedWithDeferred:
     msg: str
-    response: ResponseData  # it should be None because this class is provided
+    response: HttpResponse  # it should be None because this class is provided
 
 
 @attr.s(auto_attribs=True)
@@ -198,7 +198,7 @@ class ExtraClassDataProvider(PageObjectInputProvider):
         # we're returning a class that's not listed in self.provided_classes
         return {
             ExtraClassData: ExtraClassData("this should be returned"),
-            ResponseData: ResponseData("example.com", "this shouldn't"),
+            HttpResponse: HttpResponse("example.com", "this shouldn't"),
         }
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -198,7 +198,7 @@ class ExtraClassDataProvider(PageObjectInputProvider):
         # we're returning a class that's not listed in self.provided_classes
         return {
             ExtraClassData: ExtraClassData("this should be returned"),
-            HttpResponse: HttpResponse("example.com", "this shouldn't"),
+            HttpResponse: HttpResponse("example.com", b"this shouldn't"),
         }
 
 

--- a/tests/test_response_required_logic.py
+++ b/tests/test_response_required_logic.py
@@ -12,7 +12,7 @@ from scrapy_poet.injection import Injector, get_callback, \
 
 from scrapy_poet.page_input_providers import (
     PageObjectInputProvider,
-    ResponseDataProvider,
+    HttpResponseProvider,
 )
 from web_poet import ItemPage, WebPage
 
@@ -62,7 +62,7 @@ class FakeProductProvider(PageObjectInputProvider):
         return [FakeProductResponse(data=data)]
 
 
-class TextProductProvider(ResponseDataProvider):
+class TextProductProvider(HttpResponseProvider):
 
     # This is wrong. You should not annotate provider dependencies with classes
     # like TextResponse or HtmlResponse, you should use Response instead.
@@ -70,7 +70,7 @@ class TextProductProvider(ResponseDataProvider):
         return super().__call__(to_provide, response)
 
 
-class StringProductProvider(ResponseDataProvider):
+class StringProductProvider(HttpResponseProvider):
 
     def __call__(self, to_provide, response: str):
         return super().__call__(to_provide, response)
@@ -115,7 +115,7 @@ class MySpider(scrapy.Spider):
     name = 'foo'
     custom_settings = {
         "SCRAPY_POET_PROVIDERS": {
-            ResponseDataProvider: 1,
+            HttpResponseProvider: 1,
             DummyProductProvider: 2,
             FakeProductProvider: 3,
         }
@@ -177,7 +177,7 @@ def test_get_callback():
 
 def test_is_provider_using_response():
     assert is_provider_requiring_scrapy_response(PageObjectInputProvider) is False
-    assert is_provider_requiring_scrapy_response(ResponseDataProvider) is True
+    assert is_provider_requiring_scrapy_response(HttpResponseProvider) is True
     # TextProductProvider wrongly annotates response dependency as
     # TextResponse, instead of using the Response type.
     assert is_provider_requiring_scrapy_response(TextProductProvider) is False

--- a/tests/test_scrapy_dependencies.py
+++ b/tests/test_scrapy_dependencies.py
@@ -8,7 +8,7 @@ from web_poet.pages import ItemWebPage
 from scrapy_poet.injection import SCRAPY_PROVIDED_CLASSES
 from scrapy_poet.page_input_providers import (
     PageObjectInputProvider,
-    ResponseDataProvider,
+    HttpResponseProvider,
 )
 
 from tests.utils import crawl_items, crawl_single_item, HtmlResource
@@ -19,7 +19,7 @@ class ProductHtml(HtmlResource):
     html = """
     <html>
         <div class="breadcrumbs">
-            <a href="/food">Food</a> / 
+            <a href="/food">Food</a> /
             <a href="/food/sweets">Sweets</a>
         </div>
         <h1 class="name">Chocolate</h1>
@@ -61,7 +61,7 @@ def test_scrapy_dependencies_on_providers(scrapy_class, settings):
         url = None
         custom_settings = {
             "SCRAPY_POET_PROVIDERS": {
-                ResponseDataProvider: 1,
+                HttpResponseProvider: 1,
                 PageDataProvider: 2,
             }
         }

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest-cov
     scrapy >= 2.1.0
     pytest-twisted
-    web-poet @ git+https://git@github.com/scrapinghub/web-poet@master#egg=web-poet
+    web-poet @ git+https://git@github.com/scrapinghub/web-poet@from_bytes#egg=web-poet
 
 commands =
     py.test \

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest-cov
     scrapy >= 2.1.0
     pytest-twisted
-    web-poet @ git+https://git@github.com/scrapinghub/web-poet@from_bytes#egg=web-poet
+    web-poet @ git+https://git@github.com/scrapinghub/web-poet@master#egg=web-poet
 
 commands =
     py.test \

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest-cov
     scrapy >= 2.1.0
     pytest-twisted
-    web-poet
+    web-poet @ git+https://git@github.com/scrapinghub/web-poet@master#egg=web-poet
 
 commands =
     py.test \


### PR DESCRIPTION
Reference PR from `web_poet`: https://github.com/scrapinghub/web-poet/pull/30.

This also uses the small enhancement in https://github.com/scrapinghub/web-poet/pull/33.

### Checklist before release:

- [ ] Remove references repo in `setup.py` and `tox.ini` that prevents breaking the CI on this PR