### PR TITLE
remove from_bytes_dict() call when deserializing responses

### DIFF
--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -193,7 +193,7 @@ class HttpResponseProvider(PageObjectInputProvider, CacheDataProviderMixin):
                 response_data["url"],
                 response_data["body"],
                 status=response_data["status"],
-                headers=HttpResponseHeaders.from_bytes_dict(response_data["headers"]),
+                headers=response_data["headers"],
                 encoding=response_data["_encoding"],
             )
             for response_data in data


### PR DESCRIPTION
Reference: https://github.com/scrapinghub/scrapy-poet/pull/67#discussion_r867212146

Removing the need for this alternative constructor call since `HttpResponseHeaders` has been serialized correctly. Calling `HttpResponseHeaders.from_bytes_dict(response_data["headers"])` would be redundant.