### PR TITLE
Support retries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,9 @@ Add the following inside Scrapy's ``settings.py`` file:
     DOWNLOADER_MIDDLEWARES = {
         "scrapy_poet.InjectionMiddleware": 543,
     }
+    SPIDER_MIDDLEWARES = {
+        "scrapy_poet.RetrySpiderMiddleware": 275,
+    }
 
 Developing
 ==========

--- a/docs/intro/basic-tutorial.rst
+++ b/docs/intro/basic-tutorial.rst
@@ -113,12 +113,15 @@ extract a property from the ``to_item`` method:
 Configuring the project
 =======================
 
-To use ``scrapy-poet``, enable its downloader middleware in ``settings.py``:
+To use ``scrapy-poet``, enable its middlewares in ``settings.py``:
 
 .. code-block:: python
 
     DOWNLOADER_MIDDLEWARES = {
         'scrapy_poet.InjectionMiddleware': 543,
+    }
+    SPIDER_MIDDLEWARES = {
+        "scrapy_poet.RetrySpiderMiddleware": 275,
     }
 
 

--- a/scrapy_poet/__init__.py
+++ b/scrapy_poet/__init__.py
@@ -5,3 +5,8 @@ from .page_input_providers import (
     HttpResponseProvider,
     PageObjectInputProvider,
 )
+
+try:
+    from .spidermiddlewares import RetrySpiderMiddleware
+except ImportError:
+    pass

--- a/scrapy_poet/middleware.py
+++ b/scrapy_poet/middleware.py
@@ -3,7 +3,7 @@ responsible for injecting Page Input dependencies before the request callbacks
 are executed.
 """
 import logging
-from typing import Generator, Optional, Type, TypeVar
+from typing import Generator, List, Optional, Type, TypeVar
 
 from scrapy import Spider, signals
 from scrapy.crawler import Crawler

--- a/scrapy_poet/spidermiddlewares.py
+++ b/scrapy_poet/spidermiddlewares.py
@@ -1,0 +1,32 @@
+try:
+    from web_poet.exceptions import Retry
+except ImportError:
+    pass
+else:
+    from typing import List, Optional
+
+    from scrapy import Spider
+    from scrapy.downloadermiddlewares.retry import get_retry_request
+    from scrapy.http import Request, Response
+
+
+    class RetrySpiderMiddleware:
+        """Captures :exc:`web_poet.exceptions.Retry` exceptions from spider
+        callbacks, and retries the source request."""
+
+        def process_spider_exception(
+            self,
+            response: Response,
+            exception: BaseException,
+            spider: Spider,
+        ) -> Optional[List[Request]]:
+            if not isinstance(exception, Retry):
+                return None
+            new_request_or_none = get_retry_request(
+                response.request,
+                spider=spider,
+                reason='page_object_retry',
+            )
+            if not new_request_or_none:
+                return []
+            return [new_request_or_none]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "parsel >= 1.5.0",
         "scrapy >= 2.6.0",
         "sqlitedict >= 1.5.0",
+        "twisted >= 18.9.0",
         "url-matcher >= 0.2.0",
         "web-poet >= 0.2.0",
     ],

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -9,17 +9,20 @@ import web_poet
 from pytest_twisted import ensureDeferred, inlineCallbacks
 from scrapy import Request, Spider
 from scrapy.exceptions import IgnoreRequest
-from twisted.internet import reactor
-from twisted.internet.task import deferLater
-from twisted.web.resource import Resource
-from twisted.web.server import NOT_DONE_YET
 from web_poet import HttpClient
 from web_poet.exceptions import HttpError, HttpRequestError, HttpResponseError
 from web_poet.pages import ItemWebPage
 
 from scrapy_poet.downloader import create_scrapy_downloader
 from scrapy_poet.utils import http_request_to_scrapy_request
-from tests.utils import AsyncMock, MockServer, make_crawler
+from tests.utils import (
+    AsyncMock,
+    DelayedResource,
+    EchoResource,
+    make_crawler,
+    MockServer,
+    StatusResource,
+)
 
 
 @pytest.fixture
@@ -123,25 +126,6 @@ async def test_scrapy_poet_downloader_head_redirect(fake_http_response):
         assert scrapy_request.meta.get("dont_redirect") is True
 
 
-class LeafResource(Resource):
-    isLeaf = True
-
-    def deferRequest(self, request, delay, f, *a, **kw):
-        def _cancelrequest(_):
-            # silence CancelledError
-            d.addErrback(lambda _: None)
-            d.cancel()
-
-        d = deferLater(reactor, delay, f, *a, **kw)
-        request.notifyFinish().addErrback(_cancelrequest)
-        return d
-
-
-class EchoResource(LeafResource):
-    def render_GET(self, request):
-        return request.content.read()
-
-
 @inlineCallbacks
 def test_additional_requests_success():
     items = []
@@ -177,14 +161,6 @@ def test_additional_requests_success():
         yield crawler.crawl()
 
     assert items == [{"foo": "bar"}]
-
-
-class StatusResource(LeafResource):
-    def render_GET(self, request):
-        decoded_body = request.content.read().decode()
-        if decoded_body:
-            request.setResponseCode(int(decoded_body))
-        return b""
 
 
 @inlineCallbacks
@@ -224,23 +200,6 @@ def test_additional_requests_bad_response():
         yield crawler.crawl()
 
     assert items == [{"foo": "bar"}]
-
-
-class DelayedResource(LeafResource):
-    def render_GET(self, request):
-        decoded_body = request.content.read().decode()
-        seconds = float(decoded_body) if decoded_body else 0
-        self.deferRequest(
-            request,
-            seconds,
-            self._delayedRender,
-            request,
-            seconds,
-        )
-        return NOT_DONE_YET
-
-    def _delayedRender(self, request, seconds):
-        request.finish()
 
 
 @inlineCallbacks

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -1,0 +1,174 @@
+from pytest import importorskip
+
+Retry = importorskip("web_poet.exceptions.Retry")
+
+from collections import deque
+
+from pytest_twisted import inlineCallbacks
+from scrapy import Spider
+from web_poet.pages import ItemWebPage
+
+from tests.utils import EchoResource, make_crawler, MockServer
+
+
+@inlineCallbacks
+def test_retry_once():
+    retries = deque([True, False])
+    items = []
+
+    with MockServer(EchoResource) as server:
+
+        class ItemPage(ItemWebPage):
+
+            def to_item(self):
+                if retries.popleft():
+                    raise Retry
+                return {"foo": "bar"}
+
+        class TestSpider(Spider):
+            name = "test_spider"
+            start_urls = [server.root_url]
+
+            custom_settings = {
+                "DOWNLOADER_MIDDLEWARES": {
+                    "scrapy_poet.InjectionMiddleware": 543,
+                },
+                "SPIDER_MIDDLEWARES": {
+                    "scrapy_poet.RetrySpiderMiddleware": 275,
+                },
+            }
+
+            def parse(self, response, page: ItemPage):
+                items.append(page.to_item())
+
+        crawler = make_crawler(TestSpider, {})
+        yield crawler.crawl()
+
+    assert items == [{"foo": "bar"}]
+    assert crawler.stats.get_value("downloader/request_count") == 2
+    assert crawler.stats.get_value("retry/count") == 1
+    assert crawler.stats.get_value("retry/reason_count/page_object_retry") == 1
+    assert crawler.stats.get_value("retry/max_reached") is None
+
+
+@inlineCallbacks
+def test_retry_max():
+    # The default value of the RETRY_TIMES Scrapy setting is 2.
+    retries = deque([True, True, False])
+    items = []
+
+    with MockServer(EchoResource) as server:
+
+        class ItemPage(ItemWebPage):
+
+            def to_item(self):
+                if retries.popleft():
+                    raise Retry
+                return {"foo": "bar"}
+
+        class TestSpider(Spider):
+            name = "test_spider"
+            start_urls = [server.root_url]
+
+            custom_settings = {
+                "DOWNLOADER_MIDDLEWARES": {
+                    "scrapy_poet.InjectionMiddleware": 543,
+                },
+                "SPIDER_MIDDLEWARES": {
+                    "scrapy_poet.RetrySpiderMiddleware": 275,
+                },
+            }
+
+            def parse(self, response, page: ItemPage):
+                items.append(page.to_item())
+
+        crawler = make_crawler(TestSpider, {})
+        yield crawler.crawl()
+
+    assert items == [{"foo": "bar"}]
+    assert crawler.stats.get_value("downloader/request_count") == 3
+    assert crawler.stats.get_value("retry/count") == 2
+    assert crawler.stats.get_value("retry/reason_count/page_object_retry") == 2
+    assert crawler.stats.get_value("retry/max_reached") is None
+
+
+@inlineCallbacks
+def test_retry_exceeded():
+    # The default value of the RETRY_TIMES Scrapy setting is 2.
+    retries = deque([True, True, True])
+    items = []
+
+    with MockServer(EchoResource) as server:
+
+        class ItemPage(ItemWebPage):
+
+            def to_item(self):
+                if retries.popleft():
+                    raise Retry
+                return {"foo": "bar"}
+
+        class TestSpider(Spider):
+            name = "test_spider"
+            start_urls = [server.root_url]
+
+            custom_settings = {
+                "DOWNLOADER_MIDDLEWARES": {
+                    "scrapy_poet.InjectionMiddleware": 543,
+                },
+                "SPIDER_MIDDLEWARES": {
+                    "scrapy_poet.RetrySpiderMiddleware": 275,
+                },
+            }
+
+            def parse(self, response, page: ItemPage):
+                items.append(page.to_item())
+
+        crawler = make_crawler(TestSpider, {})
+        yield crawler.crawl()
+
+    assert items == []
+    assert crawler.stats.get_value("downloader/request_count") == 3
+    assert crawler.stats.get_value("retry/count") == 2
+    assert crawler.stats.get_value("retry/reason_count/page_object_retry") == 2
+    assert crawler.stats.get_value("retry/max_reached") == 1
+
+
+@inlineCallbacks
+def test_retry_max_configuration():
+    retries = deque([True, True, True, False])
+    items = []
+
+    with MockServer(EchoResource) as server:
+
+        class ItemPage(ItemWebPage):
+
+            def to_item(self):
+                if retries.popleft():
+                    raise Retry
+                return {"foo": "bar"}
+
+        class TestSpider(Spider):
+            name = "test_spider"
+            start_urls = [server.root_url]
+
+            custom_settings = {
+                "DOWNLOADER_MIDDLEWARES": {
+                    "scrapy_poet.InjectionMiddleware": 543,
+                },
+                "RETRY_TIMES": 3,
+                "SPIDER_MIDDLEWARES": {
+                    "scrapy_poet.RetrySpiderMiddleware": 275,
+                },
+            }
+
+            def parse(self, response, page: ItemPage):
+                items.append(page.to_item())
+
+        crawler = make_crawler(TestSpider, {})
+        yield crawler.crawl()
+
+    assert items == [{"foo": "bar"}]
+    assert crawler.stats.get_value("downloader/request_count") == 4
+    assert crawler.stats.get_value("retry/count") == 3
+    assert crawler.stats.get_value("retry/reason_count/page_object_retry") == 3
+    assert crawler.stats.get_value("retry/max_reached") is None

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
 [tox]
 envlist = min,py37,py38,py39,py310,asyncio,asyncio-min,mypy,docs
 
-[testenv]
+[base]
 deps =
     pytest
     pytest-cov
     pytest-twisted
+
+[testenv]
+deps =
+    {[base]deps}
+    git+https://github.com/scrapinghub/web-poet.git#egg=web-poet
 
 commands =
     py.test \
@@ -20,7 +25,7 @@ commands =
 [testenv:min]
 basepython = python3.7
 deps =
-    {[testenv]deps}
+    {[base]deps}
     andi==0.4.1
     attrs==21.3.0
     parsel==1.5.0


### PR DESCRIPTION
Before we merge, we need:
- A release of web-poet with Retry support.
- To update `setup.py`, and undo the change in `tox.ini` introducing a web-poet installation from Git.

This implementation maintains support for web-poet 0.2.0. However, it probably makes sense to drop it instead and keep the code simpler.

I also wonder if it makes sense to deprecate `scrapy_poet.middleware` and move its content to `scrapy_poet.downloadermiddlewares`. Although if we drop support for web-poet 0.2.0, merging `scrapy_poet.spidermiddlewares` into `scrapy_poet.middleware` is also a valid option.