### PR TITLE
create ResponseUrlProvider

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+TBR
+---
+
+* Provider for ``web_poet.ResponseUrl`` is added, which allows to access the
+  response URL in the page object. This triggers a download unlike the provider
+  for ``web_poet.RequestUrl``.
+
 0.5.1 (2022-07-28)
 ------------------
 

--- a/scrapy_poet/downloadermiddlewares.py
+++ b/scrapy_poet/downloadermiddlewares.py
@@ -19,6 +19,7 @@ from .page_input_providers import (
     HttpResponseProvider,
     PageParamsProvider,
     RequestUrlProvider,
+    ResponseUrlProvider,
 )
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ DEFAULT_PROVIDERS = {
     HttpClientProvider: 600,
     PageParamsProvider: 700,
     RequestUrlProvider: 800,
+    ResponseUrlProvider: 900,
 }
 
 InjectionMiddlewareTV = TypeVar("InjectionMiddlewareTV", bound="InjectionMiddleware")

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -23,6 +23,7 @@ from web_poet import (
     HttpResponseHeaders,
     PageParams,
     RequestUrl,
+    ResponseUrl,
 )
 
 from scrapy_poet.downloader import create_scrapy_downloader
@@ -238,5 +239,15 @@ class RequestUrlProvider(PageObjectInputProvider):
     name = "request_url"
 
     def __call__(self, to_provide: Set[Callable], request: Request):
-        """Builds a ``RequestUrl`` instance using a Scrapy ``Request``"""
+        """Builds a ``RequestUrl`` instance using a Scrapy ``Request``."""
         return [RequestUrl(url=request.url)]
+
+
+class ResponseUrlProvider(PageObjectInputProvider):
+
+    provided_classes = {ResponseUrl}
+    name = "response_url"
+
+    def __call__(self, to_provide: Set[Callable], response: Response):
+        """Builds a ``ResponseUrl`` instance using a Scrapy ``Response``."""
+        return [ResponseUrl(url=response.url)]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -379,11 +379,11 @@ def test_skip_download_response_url(settings):
 
 
 @attr.s(auto_attribs=True)
-class ResponseUrlPage(ItemPage):
-    url: ResponseUrl
+class ResponseUrlPage(WebPage):
+    response_url: ResponseUrl
 
     def to_item(self):
-        return {"url": self.url}
+        return {"response_url": self.response_url}
 
 
 class ResponseUrlPageSpider(scrapy.Spider):
@@ -401,8 +401,8 @@ def test_skip_download_response_url_page(settings):
     item, url, crawler = yield crawl_single_item(
         ResponseUrlPageSpider, ProductHtml, settings
     )
-    assert tuple(item.keys()) == ("url",)
-    assert str(item["url"]) == url
+    assert tuple(item.keys()) == ("response_url",)
+    assert str(item["response_url"]) == url
     # Even if the spider marked the response with DummyResponse, the response
     # is still needed since ResponseUrl depends on it.
     assert crawler.stats.get_stats().get("downloader/request_count", 0) == 1

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -383,7 +383,7 @@ class ResponseUrlPage(ItemPage):
     url: ResponseUrl
 
     def to_item(self):
-        return {'url': self.url}
+        return {"url": self.url}
 
 
 class ResponseUrlPageSpider(scrapy.Spider):
@@ -399,13 +399,14 @@ class ResponseUrlPageSpider(scrapy.Spider):
 @inlineCallbacks
 def test_skip_download_response_url_page(settings):
     item, url, crawler = yield crawl_single_item(
-        RequestUrlPageSpider, ProductHtml, settings)
-    assert tuple(item.keys()) == ('url',)
-    assert str(item['url']) == url
-    # Compared to the earlier test in test_skip_download_response_url(), the
-    # DummyResponse here worked since the response was handled in the PO.
-    assert crawler.stats.get_stats().get('downloader/request_count', 0) == 0
-    assert crawler.stats.get_stats().get('scrapy_poet/dummy_response_count', 0) == 1
+        ResponseUrlPageSpider, ProductHtml, settings
+    )
+    assert tuple(item.keys()) == ("url",)
+    assert str(item["url"]) == url
+    # Even if the spider marked the response with DummyResponse, the response
+    # is still needed since ResponseUrl depends on it.
+    assert crawler.stats.get_stats().get("downloader/request_count", 0) == 1
+    assert crawler.stats.get_stats().get("scrapy_poet/dummy_response_count", 0) == 0
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
Partially resolves #83.

The only thing missing here is ensuring that the providers are powerful enough such that having a dependency of `HttpResponse` and `BrowserHtml` would not trigger downloading the page twice (using the `ResponseUrl` from the `BrowserHtml` is preferred if available). However, `web-poet` needs to be updated to add a url component to `BrowserHtml`.

Checklist:
- [x] Basic implementation
- [x] Changelog
