### PR TITLE
improve visibility of settings.py config in the docs

### DIFF
--- a/docs/intro/basic-tutorial.rst
+++ b/docs/intro/basic-tutorial.rst
@@ -110,26 +110,13 @@ extract a property from the ``to_item`` method:
                 "name": self.title,
             }
 
-Configuring the project
-=======================
-
-To use ``scrapy-poet``, enable its middlewares in ``settings.py``:
-
-.. code-block:: python
-
-    DOWNLOADER_MIDDLEWARES = {
-        "scrapy_poet.InjectionMiddleware": 543,
-    }
-    SPIDER_MIDDLEWARES = {
-        "scrapy_poet.RetryMiddleware": 275,
-    }
-
-
-``BookPage`` class we created previously can be used without ``scrapy-poet``,
+The ``BookPage`` class we created can be used without ``scrapy-poet``,
 and even without Scrapy (note that imports were from ``web_poet`` so far).
+``scrapy-poet`` makes it easy to use `web-poet`_ Page Objects (such as
+``BookPage``) in Scrapy spiders.
 
-``scrapy-poet`` makes it easy to use `web-poet`_ Page Objects
-(such as ``BookPage``) in Scrapy spiders.
+See the :ref:`intro-install` page on how to install and configure ``scrapy-poet``
+in your project.
 
 Changing spider
 ===============

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -18,6 +18,21 @@ If you’re already familiar with installation of Python packages, you can insta
 
 Scrapy 2.6.0 or above is required and it has to be installed separately.
 
+Configuring the project
+=======================
+
+To use ``scrapy-poet``, enable its middlewares in the ``settings.py`` file
+of your Scrapy project:
+
+.. code-block:: python
+
+    DOWNLOADER_MIDDLEWARES = {
+        "scrapy_poet.InjectionMiddleware": 543,
+    }
+    SPIDER_MIDDLEWARES = {
+        "scrapy_poet.RetryMiddleware": 275,
+    }
+
 Things that are good to know
 ============================
 


### PR DESCRIPTION
Our `settings.py` config is tucked away in another page, adding some friction on how users could quickly set it up in their projects.