### PR TITLE
fix failing 'docs' CI env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,14 +43,10 @@ deps =
 commands = mypy --ignore-missing-imports --no-warn-no-return scrapy_poet tests
 
 [docs]
+basepython = python3
 changedir = docs
 deps =
     -rdocs/requirements.txt
-
-[testenv:docs]
-basepython = python3
-changedir = {[docs]changedir}
-deps = {[docs]deps}
 commands =
     sphinx-build -W -b html . {envtmpdir}/html
 


### PR DESCRIPTION
The issue was due to a new tox v4 which has some backward incompatible changes.