### PR TITLE
official support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,17 +21,12 @@ jobs:
           toxenv: "min"
         - python-version: "3.7"
           toxenv: "asyncio-min"
-
         - python-version: "3.8"
           toxenv: "py"
         - python-version: "3.9"
           toxenv: "py"
-
         - python-version: "3.10"
           toxenv: "py"
-        - python-version: "3.10"
-          toxenv: "asyncio"
-
         - python-version: "3.11"
           toxenv: "py"
         - python-version: "3.11"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,11 @@ jobs:
         - python-version: "3.10"
           toxenv: "asyncio"
 
+        - python-version: "3.11"
+          toxenv: "py"
+        - python-version: "3.11"
+          toxenv: "asyncio"
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -56,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
         tox-job: ["mypy", "docs", "linters"]
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+TBR
+---
+
+* Official support for Python 3.11
+
 0.6.0 (2022-11-24)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = min,py37,py38,py39,py310,asyncio,asyncio-min,mypy,docs
+envlist = min,py37,py38,py39,py310,py311,asyncio,asyncio-min,mypy,docs
 
 [testenv]
 deps =


### PR DESCRIPTION
I'm excited to have better error message in our CI as per this new feature: https://docs.python.org/3/whatsnew/3.11.html#pep-657-fine-grained-error-locations-in-tracebacks