### PR TITLE
tox: declare 'testenv' in docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
 
 commands = mypy --ignore-missing-imports --no-warn-no-return scrapy_poet tests
 
-[docs]
+[testenv:docs]
 basepython = python3
 changedir = docs
 deps =


### PR DESCRIPTION
In the past few weeks, a fix in https://github.com/scrapinghub/scrapy-poet/pull/101 has been created to fix the failing CI due to the new tox v4 release.

After some time, tox released another update which causes our **docs** env to not build the sphinx docs but instead run the unit tests. Reference: https://github.com/scrapinghub/scrapy-poet/actions/runs/3827563316/jobs/6512254767