### PR TITLE
bump doc dep sphinx-td-theme 0.4 → 1.1.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 Scrapy >= 2.6.0
 Sphinx >= 3.0.3
-sphinx-rtd-theme >= 0.4
+sphinx-rtd-theme >= 1.1.0


### PR DESCRIPTION
This fixes some of the bullet point formatting issues in our docs.

# Before

![image](https://user-images.githubusercontent.com/3449761/210337211-c9547ce9-27ff-4245-aec1-fb1142cd0631.png)

---

![image](https://user-images.githubusercontent.com/3449761/210337436-9ae2ae22-3357-44dd-9dad-9394553503a6.png)


# After

![image](https://user-images.githubusercontent.com/3449761/210337238-1a6ca71d-2b2f-4468-933a-c0f2a0988fac.png)

---

![image](https://user-images.githubusercontent.com/3449761/210337468-2131ebd5-4a4d-4eea-a73d-e4210bda48ca.png)

