### PR TITLE
WIP: `Annotated[Item, PickFields("x", "y")]` to decide which fields to populate in callback

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -11,6 +11,10 @@ API
    :members:
    :no-special-members:
 
+.. autoclass:: scrapy_poet.PickFields
+   :members:
+   :no-special-members:
+
 Injection Middleware
 ====================
 

--- a/scrapy_poet/__init__.py
+++ b/scrapy_poet/__init__.py
@@ -1,4 +1,4 @@
-from .api import DummyResponse, callback_for
+from .api import DummyResponse, PickFields, callback_for
 from .downloadermiddlewares import InjectionMiddleware
 from .page_input_providers import (
     CacheDataProviderMixin,

--- a/scrapy_poet/api.py
+++ b/scrapy_poet/api.py
@@ -1,5 +1,5 @@
 from inspect import iscoroutinefunction
-from typing import Callable, Optional, Type
+from typing import Callable, Iterable, Optional, Type
 
 from scrapy.http import Request, Response
 from web_poet.pages import ItemPage
@@ -130,3 +130,10 @@ def callback_for(page_or_item_cls: Type) -> Callable:
 
     setattr(parse, _CALLBACK_FOR_MARKER, True)
     return parse
+
+
+class PickFields:
+    """TODO: docstring"""
+
+    def __init__(self, *args: Iterable[str]):
+        self.fields = tuple(args)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "twisted >= 18.9.0",
         "url-matcher >= 0.2.0",
         "web-poet >= 0.6.0",
+        "typing_extensions >= 4.4.0; python_version<'3.9'",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
A continuation for https://github.com/scrapinghub/scrapy-poet/pull/88 but built on top of https://github.com/scrapinghub/scrapy-poet/pull/103 to reduce the chances of merge conflicts later on when writing the docs.

# TODO:

- [ ] avoid returning cached full-items as-is, vice-versa
- [ ] raise error when FieldPick has field not in PO
- [ ] handle the inconsistencies of `Annotated` in different Python versions
- [ ] more tests

When we're happy with the API:

- [ ] Changelog
- [ ] Docs

