### PR TITLE
include `SCRAPY_POET_RULES` in install docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,9 @@ Add the following inside Scrapy's ``settings.py`` file:
         "scrapy_poet.RetryMiddleware": 275,
     }
 
+    from web_poet import default_registry
+    SCRAPY_POET_RULES = default_registry.get_rules()
+
 Developing
 ==========
 

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -33,6 +33,9 @@ of your Scrapy project:
         "scrapy_poet.RetryMiddleware": 275,
     }
 
+    from web_poet import default_registry
+    SCRAPY_POET_RULES = default_registry.get_rules()
+
 Things that are good to know
 ============================
 


### PR DESCRIPTION
I tried setting up a Scrapy project from scratch using our tutorials, i.e., copy-pasting the code from the installation section.

Took me a while to figure out why the Item Provider wasn't working. It was due to not declaring the `SCRAPY_POET_RULES` in the settings. :sweat\_smile: 

I think we can prevent this from happening by including it directly in the docs, especially now that we're encouraging items than overrides.