### PR TITLE
Default: `SCRAPY_POET_RULES = web_poet.default_registry.get_rules()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,6 +75,8 @@ TBR
       a deadlock in their sub-dependencies, e.g. due to a circular dependency
       between page objects.
 
+* New setting named ``SCRAPY_POET_MODULES``.
+
 * Moved some of the utility functions from the test module into
   ``scrapy_poet.utils.testing``.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,7 +75,7 @@ TBR
       a deadlock in their sub-dependencies, e.g. due to a circular dependency
       between page objects.
 
-* New setting named ``SCRAPY_POET_MODULES``.
+* New setting named ``SCRAPY_POET_DISCOVER``.
 
 * Moved some of the utility functions from the test module into
   ``scrapy_poet.utils.testing``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,7 +83,8 @@ TBR
 * Deprecations:
 
     * The ``SCRAPY_POET_OVERRIDES`` setting has been replaced by
-      ``SCRAPY_POET_RULES``.
+      ``SCRAPY_POET_RULES`` which now, by default,
+      uses :meth:`web_poet.default_registry.get_rules`.
 
 * Backward incompatible changes:
 

--- a/docs/intro/basic-tutorial.rst
+++ b/docs/intro/basic-tutorial.rst
@@ -511,14 +511,15 @@ and store the :py:class:`web_poet.rules.ApplyRule` for you. All of the
     # rules from other packages. Otherwise, it can be omitted.
     # More info about this caveat on web-poet docs.
     consume_modules("external_package_A", "another_ext_package.lib")
-    SCRAPY_POET_RULES = default_registry.get_rules()
 
 .. note::
 
-    By default, ``SCRAPY_POET_RULES`` has values already set to
-    :meth:`web_poet.default_registry.get_rules`. However, if you need to add 
-    rules from other external packages, make sure to use
-    :func:`web_poet.rules.consume_modules` as shown above.
+    By default, ``SCRAPY_POET_RULES`` already has some rules set from the
+    return value of :meth:`web_poet.default_registry.get_rules()
+    <web_poet.rules.RulesRegistry.get_rules>`. However, if you need to add rules
+    from other external packages, make sure to use
+    :func:`web_poet.consume_modules <web_poet.rules.consume_modules>` as shown
+    above inside your ``settings.py``.
 
 For more info on this, you can refer to these docs:
 

--- a/docs/intro/basic-tutorial.rst
+++ b/docs/intro/basic-tutorial.rst
@@ -513,6 +513,13 @@ and store the :py:class:`web_poet.rules.ApplyRule` for you. All of the
     consume_modules("external_package_A", "another_ext_package.lib")
     SCRAPY_POET_RULES = default_registry.get_rules()
 
+.. note::
+
+    By default, ``SCRAPY_POET_RULES`` has values already set to
+    :meth:`web_poet.default_registry.get_rules`. However, if you need to add 
+    rules from other external packages, make sure to use
+    :func:`web_poet.rules.consume_modules` as shown above.
+
 For more info on this, you can refer to these docs:
 
     * ``scrapy-poet``'s :ref:`rules-from-web-poet` Tutorial section.

--- a/docs/intro/basic-tutorial.rst
+++ b/docs/intro/basic-tutorial.rst
@@ -498,12 +498,15 @@ is accepted and it would restrict the override only to category pages.
     Also see the `url-matcher <https://url-matcher.readthedocs.io/en/stable/>`_
     documentation for more information about the patterns syntax.
 
-Manually defining overrides like this would be inconvenient, most
-especially for larger projects. Fortunately, `web-poet`_ has a cool feature to
-annotate Page Objects like :py:func:`web_poet.handle_urls` that would define
-and store the :class:`web_poet.ApplyRule <web_poet.rules.ApplyRule>` for you.
-All of the :class:`web_poet.ApplyRule <web_poet.rules.ApplyRule>` rules could
-then be simply read as:
+Manually defining overrides like this would be inconvenient, most especially for
+larger projects. Fortunately, ``scrapy-poet`` already retrieves the rules defined
+from `web-poet`_'s ``default_registry``. This is done by setting the default
+value of the ``SCRAPY_POET_RULES`` setting as
+:meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`.
+
+However, if you need to add rules from other external packages, make sure to use
+:func:`web_poet.consume_modules <web_poet.rules.consume_modules>` inside your
+``settings.py`` file as shown below.
 
 .. code:: python
 
@@ -513,15 +516,6 @@ then be simply read as:
     # rules from other packages. Otherwise, it can be omitted.
     # More info about this caveat on web-poet docs.
     consume_modules("external_package_A", "another_ext_package.lib")
-
-.. note::
-
-    By default, ``SCRAPY_POET_RULES`` already has some rules set from the
-    return value of :meth:`web_poet.default_registry.get_rules()
-    <web_poet.rules.RulesRegistry.get_rules>`. However, if you need to add rules
-    from other external packages, make sure to use
-    :func:`web_poet.consume_modules <web_poet.rules.consume_modules>` as shown
-    above inside your ``settings.py``.
 
 For more info on this, you can refer to these docs:
 

--- a/docs/intro/basic-tutorial.rst
+++ b/docs/intro/basic-tutorial.rst
@@ -506,7 +506,7 @@ value of the ``SCRAPY_POET_RULES`` setting as
 
 However, this only works if page objects are annotated using the
 :func:`web_poet.handle_urls` decorator. You also need to set the
-``SCRAPY_POET_MODULES`` setting so that these rules could be properly imported.
+``SCRAPY_POET_DISCOVER`` setting so that these rules could be properly imported.
 
 For more info on this, you can refer to these docs:
 

--- a/docs/intro/basic-tutorial.rst
+++ b/docs/intro/basic-tutorial.rst
@@ -499,23 +499,14 @@ is accepted and it would restrict the override only to category pages.
     documentation for more information about the patterns syntax.
 
 Manually defining overrides like this would be inconvenient, most especially for
-larger projects. Fortunately, ``scrapy-poet`` already retrieves the rules defined
+larger projects. Fortunately, scrapy-poet already retrieves the rules defined
 from `web-poet`_'s ``default_registry``. This is done by setting the default
 value of the ``SCRAPY_POET_RULES`` setting as
 :meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`.
 
-However, if you need to add rules from other external packages, make sure to use
-:func:`web_poet.consume_modules <web_poet.rules.consume_modules>` inside your
-``settings.py`` file as shown below.
-
-.. code:: python
-
-    from web_poet import default_registry, consume_modules
-
-    # The consume_modules() must be called first if you need to properly import
-    # rules from other packages. Otherwise, it can be omitted.
-    # More info about this caveat on web-poet docs.
-    consume_modules("external_package_A", "another_ext_package.lib")
+However, this only works if page objects are annotated using the
+:func:`web_poet.handle_urls` decorator. You also need to set the
+``SCRAPY_POET_MODULES`` setting so that these rules could be properly imported.
 
 For more info on this, you can refer to these docs:
 

--- a/docs/rules-from-web-poet.rst
+++ b/docs/rules-from-web-poet.rst
@@ -187,6 +187,14 @@ For example:
     # To get all of the Override Rules that were declared via annotations.
     SCRAPY_POET_RULES = default_registry.get_rules()
 
+ 
+.. note::
+
+    By default, ``SCRAPY_POET_RULES`` has values already set to
+    :meth:`web_poet.default_registry.get_rules`. However, if you need to add 
+    rules from other external packages, make sure to use
+    :func:`web_poet.rules.consume_modules` as shown above.
+
 The :py:meth:`web_poet.rules.RulesRegistry.get_rules` method of the
 ``default_registry`` above returns ``List[ApplyRule]`` that were declared
 using `web-poet`_'s :py:func:`web_poet.handle_urls` annotation. This is much

--- a/docs/rules-from-web-poet.rst
+++ b/docs/rules-from-web-poet.rst
@@ -173,27 +173,12 @@ for the domain ``toscrape.com``.
 Using the rules in scrapy-poet
 ------------------------------
 
-``scrapy-poet`` automatically uses the rules defined by the ``@handle_urls``
-annotation by having the default value of the ``SCRAPY_POET_RULES`` setting set to
-:meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`.
-The :py:meth:`get_rules() <web_poet.rules.RulesRegistry.get_rules>` method of the
-``default_registry`` returns a ``List[ApplyRule]``.
-
-However, if you need to add rules from other external packages, make sure to use
-:func:`web_poet.consume_modules <web_poet.rules.consume_modules>` inside your
-``settings.py`` file as shown below.
-
-.. code-block:: python
-
-    from web_poet import default_registry, consume_modules
-
-    # The consume_modules() must be called first if you need to properly import
-    # rules from other packages. Otherwise, it can be omitted.
-    # More info about this caveat on web-poet docs.
-    consume_modules("external_package_A", "another_ext_package.lib")
-
-Take note that you can modify the values of the ``SCRAPY_POET_RULES`` setting
-since it's simply structured as ``List[ApplyRule]``.
+scrapy-poet automatically uses the rules defined by page objects annotated
+with the :func:`web_poet.handle_urls` decorator by having the default value of the
+``SCRAPY_POET_RULES`` setting set to
+:meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`,
+which returns a ``List[ApplyRule]``. Moreover, you also need to set the
+``SCRAPY_POET_MODULES`` setting so that these rules could be properly imported.
 
 .. note::
 

--- a/docs/rules-from-web-poet.rst
+++ b/docs/rules-from-web-poet.rst
@@ -170,12 +170,18 @@ The :py:func:`web_poet.handle_urls` decorator in this case is indicating that
 the class ``BSTBookPage`` should be used instead of ``BookPage``
 for the domain ``toscrape.com``.
 
-In order to configure the ``scrapy-poet`` overrides automatically
-using these annotations, you can directly interact with `web-poet`_'s
-``default_registry`` (an instance of :py:class:`web_poet.RulesRegistry
-<web_poet.rules.RulesRegistry>`).
+Using the rules in scrapy-poet
+------------------------------
 
-For example:
+``scrapy-poet`` automatically uses the rules defined by the ``@handle_urls``
+annotation by having the default value of the ``SCRAPY_POET_RULES`` setting set to
+:meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`.
+The :py:meth:`get_rules() <web_poet.rules.RulesRegistry.get_rules>` method of the
+``default_registry`` returns a ``List[ApplyRule]``.
+
+However, if you need to add rules from other external packages, make sure to use
+:func:`web_poet.consume_modules <web_poet.rules.consume_modules>` inside your
+``settings.py`` file as shown below.
 
 .. code-block:: python
 
@@ -186,23 +192,8 @@ For example:
     # More info about this caveat on web-poet docs.
     consume_modules("external_package_A", "another_ext_package.lib")
 
-.. note::
-
-    By default, ``SCRAPY_POET_RULES`` already has some rules set from the
-    return value of :meth:`web_poet.default_registry.get_rules()
-    <web_poet.rules.RulesRegistry.get_rules>`. However, if you need to add rules
-    from other external packages, make sure to use
-    :func:`web_poet.consume_modules <web_poet.rules.consume_modules>` as shown
-    above inside your ``settings.py``.
-
-The :py:meth:`web_poet.RulesRegistry.get_rules <web_poet.rules.RulesRegistry.get_rules>`
-method of the ``default_registry`` above returns ``List[ApplyRule]`` that were
-declared using `web-poet`_'s :py:func:`web_poet.handle_urls` annotation. This is
-much more convenient that manually defining all of the :class:`web_poet.ApplyRule
-<web_poet.rules.ApplyRule>`.
-
-Take note that since ``SCRAPY_POET_RULES`` is structured as
-``List[ApplyRule]``, you can easily modify it later on if needed.
+Take note that you can modify the values of the ``SCRAPY_POET_RULES`` setting
+since it's simply structured as ``List[ApplyRule]``.
 
 .. note::
 

--- a/docs/rules-from-web-poet.rst
+++ b/docs/rules-from-web-poet.rst
@@ -184,16 +184,14 @@ For example:
     # More info about this caveat on web-poet docs.
     consume_modules("external_package_A", "another_ext_package.lib")
 
-    # To get all of the Override Rules that were declared via annotations.
-    SCRAPY_POET_RULES = default_registry.get_rules()
-
- 
 .. note::
 
-    By default, ``SCRAPY_POET_RULES`` has values already set to
-    :meth:`web_poet.default_registry.get_rules`. However, if you need to add 
-    rules from other external packages, make sure to use
-    :func:`web_poet.rules.consume_modules` as shown above.
+    By default, ``SCRAPY_POET_RULES`` already has some rules set from the
+    return value of :meth:`web_poet.default_registry.get_rules()
+    <web_poet.rules.RulesRegistry.get_rules>`. However, if you need to add rules
+    from other external packages, make sure to use
+    :func:`web_poet.consume_modules <web_poet.rules.consume_modules>` as shown
+    above inside your ``settings.py``.
 
 The :py:meth:`web_poet.rules.RulesRegistry.get_rules` method of the
 ``default_registry`` above returns ``List[ApplyRule]`` that were declared

--- a/docs/rules-from-web-poet.rst
+++ b/docs/rules-from-web-poet.rst
@@ -178,7 +178,7 @@ with the :func:`web_poet.handle_urls` decorator by having the default value of t
 ``SCRAPY_POET_RULES`` setting set to
 :meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`,
 which returns a ``List[ApplyRule]``. Moreover, you also need to set the
-``SCRAPY_POET_MODULES`` setting so that these rules could be properly imported.
+``SCRAPY_POET_DISCOVER`` setting so that these rules could be properly imported.
 
 .. note::
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -26,9 +26,30 @@ Deprecated. Use ``SCRAPY_POET_RULES`` instead.
 SCRAPY_POET_RULES
 -----------------
 
-Default: ``None``
+Default: :meth:`web_poet.default_registry.get_rules()`
 
-Accepts an ``Iterable[ApplyRule]`` which sets the rules to use.
+.. warning::
+
+    Although ``SCRAPY_POET_RULES`` already has values from the ``default_registry``,
+    make sure you call :func:`web_poet.rules.consume_modules` if you're using
+    other rules from other external packages.
+
+    Example:
+
+    .. code-block:: python
+
+        from web_poet import default_registry, consume_modules
+
+        # The consume_modules() must be called first if you need to properly import
+        # rules from other packages. Otherwise, it can be omitted.
+        # More info about this caveat on web-poet docs.
+        consume_modules("external_package_A", "another_ext_package.lib")
+
+        # To get all of the Override Rules that were declared via annotations.
+        SCRAPY_POET_RULES = default_registry.get_rules()
+
+
+Accepts a ``List[ApplyRule]`` which sets the rules to use.
 
 There are sections dedicated for this at :ref:`intro-tutorial` and
 :ref:`rules-from-web-poet`.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -35,13 +35,19 @@ Accepts a ``List[ApplyRule]`` which sets the rules to use.
 
     Although ``SCRAPY_POET_RULES`` already has values set from the return value of
     :meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`,
-    make sure you call :func:`web_poet.consume_modules <web_poet.rules.consume_modules>`
-    inside your ``settings.py`` file if you're using other rules from other external
-    packages which contain page objects annotated with ``@handle_urls``.
+    make sure to also set the ``SCRAPY_POET_MODULES`` setting below.
 
 There are sections dedicated for this at :ref:`intro-tutorial` and
 :ref:`rules-from-web-poet`.
 
+SCRAPY_POET_MODULES
+-------------------
+
+Default: ``[]``
+
+A list of modules (i.e. ``List[str]``) which scrapy-poet will look for page objects
+annotated with the :func:`web_poet.handle_urls` decorator. Each module is passed
+into :func:`web_poet.consume_modules <web_poet.rules.consume_modules>`.
 
 SCRAPY_POET_CACHE
 -----------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -35,13 +35,13 @@ Accepts a ``List[ApplyRule]`` which sets the rules to use.
 
     Although ``SCRAPY_POET_RULES`` already has values set from the return value of
     :meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`,
-    make sure to also set the ``SCRAPY_POET_MODULES`` setting below.
+    make sure to also set the ``SCRAPY_POET_DISCOVER`` setting below.
 
 There are sections dedicated for this at :ref:`intro-tutorial` and
 :ref:`rules-from-web-poet`.
 
-SCRAPY_POET_MODULES
--------------------
+SCRAPY_POET_DISCOVER
+--------------------
 
 Default: ``[]``
 
@@ -56,8 +56,8 @@ This ensures that when using the default value of ``SCRAPY_POET_RULES`` set to
 it should contain all the intended rules.
 
 Note that it's also possible for ``SCRAPY_POET_RULES`` to have rules not specified
-in ``SCRAPY_POET_MODULES`` (e.g. when the annotated page objects are inside your
-Scrapy project). However, it's recommended to still use ``SCRAPY_POET_MODULES``
+in ``SCRAPY_POET_DISCOVER`` (e.g. when the annotated page objects are inside your
+Scrapy project). However, it's recommended to still use ``SCRAPY_POET_DISCOVER``
 to ensure all the intended rules are properly loaded.
 
 SCRAPY_POET_CACHE

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -45,9 +45,20 @@ SCRAPY_POET_MODULES
 
 Default: ``[]``
 
-A list of modules (i.e. ``List[str]``) which scrapy-poet will look for page objects
-annotated with the :func:`web_poet.handle_urls` decorator. Each module is passed
-into :func:`web_poet.consume_modules <web_poet.rules.consume_modules>`.
+A list of packages/modules (i.e. ``List[str]``) which scrapy-poet will look for
+page objects annotated with the :func:`web_poet.handle_urls` decorator. Each
+package/module is passed into
+:func:`web_poet.consume_modules <web_poet.rules.consume_modules>` where each
+module from a package is recursively loaded.
+
+This ensures that when using the default value of ``SCRAPY_POET_RULES`` set to
+:meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`,
+it should contain all the intended rules.
+
+Note that it's also possible for ``SCRAPY_POET_RULES`` to have rules not specified
+in ``SCRAPY_POET_MODULES`` (e.g. when the annotated page objects are inside your
+Scrapy project). However, it's recommended to still use ``SCRAPY_POET_MODULES``
+to ensure all the intended rules are properly loaded.
 
 SCRAPY_POET_CACHE
 -----------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -26,28 +26,15 @@ Deprecated. Use ``SCRAPY_POET_RULES`` instead.
 SCRAPY_POET_RULES
 -----------------
 
-Default: :meth:`web_poet.default_registry.get_rules()`
+Default: :meth:`web_poet.default_registry.get_rules()
+<web_poet.rules.RulesRegistry.get_rules>`
 
 .. warning::
 
-    Although ``SCRAPY_POET_RULES`` already has values from the ``default_registry``,
-    make sure you call :func:`web_poet.rules.consume_modules` if you're using
-    other rules from other external packages.
-
-    Example:
-
-    .. code-block:: python
-
-        from web_poet import default_registry, consume_modules
-
-        # The consume_modules() must be called first if you need to properly import
-        # rules from other packages. Otherwise, it can be omitted.
-        # More info about this caveat on web-poet docs.
-        consume_modules("external_package_A", "another_ext_package.lib")
-
-        # To get all of the Override Rules that were declared via annotations.
-        SCRAPY_POET_RULES = default_registry.get_rules()
-
+    Although ``SCRAPY_POET_RULES`` already has values set from the return value of
+    :meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`,
+    make sure you call :func:`web_poet.consume_modules <web_poet.rules.consume_modules>`
+    inside your ``settings.py`` if you're using other rules from other external packages.
 
 Accepts a ``List[ApplyRule]`` which sets the rules to use.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -29,14 +29,15 @@ SCRAPY_POET_RULES
 Default: :meth:`web_poet.default_registry.get_rules()
 <web_poet.rules.RulesRegistry.get_rules>`
 
+Accepts a ``List[ApplyRule]`` which sets the rules to use.
+
 .. warning::
 
     Although ``SCRAPY_POET_RULES`` already has values set from the return value of
     :meth:`web_poet.default_registry.get_rules() <web_poet.rules.RulesRegistry.get_rules>`,
     make sure you call :func:`web_poet.consume_modules <web_poet.rules.consume_modules>`
-    inside your ``settings.py`` if you're using other rules from other external packages.
-
-Accepts a ``List[ApplyRule]`` which sets the rules to use.
+    inside your ``settings.py`` file if you're using other rules from other external
+    packages which contain page objects annotated with ``@handle_urls``.
 
 There are sections dedicated for this at :ref:`intro-tutorial` and
 :ref:`rules-from-web-poet`.

--- a/scrapy_poet/utils/__init__.py
+++ b/scrapy_poet/utils/__init__.py
@@ -5,7 +5,7 @@ from warnings import warn
 from scrapy.crawler import Crawler
 from scrapy.http import Request, Response
 from scrapy.utils.project import inside_project, project_data_dir
-from web_poet import HttpRequest, HttpResponse, HttpResponseHeaders
+from web_poet import HttpRequest, HttpResponse, HttpResponseHeaders, default_registry
 
 
 def get_scrapy_data_path(createdir: bool = True, default_dir: str = ".scrapy") -> str:
@@ -57,6 +57,6 @@ def create_registry_instance(cls: Type, crawler: Crawler):
         warn(msg, DeprecationWarning, stacklevel=2)
     rules = crawler.settings.getlist(
         "SCRAPY_POET_RULES",
-        crawler.settings.getlist("SCRAPY_POET_OVERRIDES", []),
+        crawler.settings.getlist("SCRAPY_POET_OVERRIDES", default_registry.get_rules()),
     )
     return cls(rules=rules)

--- a/scrapy_poet/utils/__init__.py
+++ b/scrapy_poet/utils/__init__.py
@@ -5,7 +5,13 @@ from warnings import warn
 from scrapy.crawler import Crawler
 from scrapy.http import Request, Response
 from scrapy.utils.project import inside_project, project_data_dir
-from web_poet import HttpRequest, HttpResponse, HttpResponseHeaders, default_registry
+from web_poet import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseHeaders,
+    consume_modules,
+    default_registry,
+)
 
 
 def get_scrapy_data_path(createdir: bool = True, default_dir: str = ".scrapy") -> str:
@@ -49,6 +55,8 @@ def scrapy_response_to_http_response(response: Response) -> HttpResponse:
 
 
 def create_registry_instance(cls: Type, crawler: Crawler):
+    for module in crawler.settings.getlist("SCRAPY_POET_MODULES", []):
+        consume_modules(module)
     if "SCRAPY_POET_OVERRIDES" in crawler.settings:
         msg = (
             "The SCRAPY_POET_OVERRIDES setting is deprecated. "

--- a/scrapy_poet/utils/__init__.py
+++ b/scrapy_poet/utils/__init__.py
@@ -55,7 +55,7 @@ def scrapy_response_to_http_response(response: Response) -> HttpResponse:
 
 
 def create_registry_instance(cls: Type, crawler: Crawler):
-    for module in crawler.settings.getlist("SCRAPY_POET_MODULES", []):
+    for module in crawler.settings.getlist("SCRAPY_POET_DISCOVER", []):
         consume_modules(module)
     if "SCRAPY_POET_OVERRIDES" in crawler.settings:
         msg = (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -179,6 +179,8 @@ def test_scrapy_response_to_http_response(scrapy_response, http_response):
 
 @mock.patch("scrapy_poet.utils.consume_modules")
 def test_create_registry_instance_SCRAPY_POET_MODULES(mock_consume_modules, settings):
+    settings.set("SCRAPY_POET_RULES", [])
+
     mock_cls = mock.Mock()
     fake_crawler = get_crawler(Spider, settings)
     create_registry_instance(mock_cls, fake_crawler)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -178,7 +178,7 @@ def test_scrapy_response_to_http_response(scrapy_response, http_response):
 
 
 @mock.patch("scrapy_poet.utils.consume_modules")
-def test_create_registry_instance_SCRAPY_POET_MODULES(mock_consume_modules, settings):
+def test_create_registry_instance_SCRAPY_POET_DISCOVER(mock_consume_modules, settings):
     settings.set("SCRAPY_POET_RULES", [])
 
     mock_cls = mock.Mock()
@@ -188,7 +188,7 @@ def test_create_registry_instance_SCRAPY_POET_MODULES(mock_consume_modules, sett
     mock_cls.assert_called_once_with(rules=[])
 
     mock_cls = mock.Mock()
-    settings.set("SCRAPY_POET_MODULES", ["a.b.c", "x.y"])
+    settings.set("SCRAPY_POET_DISCOVER", ["a.b.c", "x.y"])
     fake_crawler = get_crawler(Spider, settings)
     create_registry_instance(mock_cls, fake_crawler)
     assert mock_consume_modules.call_args_list == [mock.call("a.b.c"), mock.call("x.y")]

--- a/tests/test_web_poet_rules.py
+++ b/tests/test_web_poet_rules.py
@@ -130,6 +130,21 @@ def assert_deps(deps: List[Dict[str, Any]], expected: Dict[str, Any], size: int 
     assert all([True for k, v in expected.items() if isinstance(deps[0][k], v)])
 
 
+def assert_warning_tokens(caught_warnings, expected_warning_tokens):
+    results = []
+    for warning in caught_warnings:
+        results.append(
+            all(
+                [
+                    True
+                    for expected in expected_warning_tokens
+                    if expected in str(warning.message)
+                ]
+            )
+        )
+    assert all(results)
+
+
 @handle_urls(URL)
 class UrlMatchPage(ItemPage):
     async def to_item(self) -> dict:
@@ -451,15 +466,15 @@ def test_item_return_subclass() -> None:
     """
 
     # There should be a warning to the user about clashing rules.
-    rules = [
-        ApplyRule(URL, use=ParentProductPage, to_return=ProductFromParent),
-        ApplyRule(URL, use=SubclassProductPage, to_return=ProductFromParent),
+    expected_warning_tokens = [
+        "Consider setting the priority explicitly for these rules:",
+        repr(ApplyRule(URL, use=ParentProductPage, to_return=ProductFromParent)),
+        repr(ApplyRule(URL, use=SubclassProductPage, to_return=ProductFromParent)),
     ]
-    msg = f"Consider updating the priority of these rules: {rules}"
 
     with warnings.catch_warnings(record=True) as caught_warnings:
         item, deps = yield crawl_item_and_deps(ProductFromParent)
-        assert any([True for w in caught_warnings if msg in str(w.message)])
+        assert_warning_tokens(caught_warnings, expected_warning_tokens)
 
     assert item == ProductFromParent(name="subclass product name")
     assert_deps(deps, {"item": ProductFromParent})
@@ -503,15 +518,15 @@ def test_item_return_individually_defined() -> None:
     The latter rule that was defined should be used when the priorities are the
     same.
     """
-    rules = [
-        ApplyRule(URL, use=IndependentA1Page, to_return=AItem),
-        ApplyRule(URL, use=IndependentA2Page, to_return=AItem),
+    expected_warning_tokens = [
+        "Consider setting the priority explicitly for these rules:",
+        repr(ApplyRule(URL, use=IndependentA1Page, to_return=AItem)),
+        repr(ApplyRule(URL, use=IndependentA2Page, to_return=AItem)),
     ]
-    msg = f"Consider updating the priority of these rules: {rules}"
 
     with warnings.catch_warnings(record=True) as caught_warnings:
         item, deps = yield crawl_item_and_deps(AItem)
-        assert any([True for w in caught_warnings if msg in str(w.message)])
+        assert_warning_tokens(caught_warnings, expected_warning_tokens)
 
     assert item == AItem(name="independent A2")
     assert_deps(deps, {"item": IndependentA2Page})


### PR DESCRIPTION
Stemming from the discussion in https://github.com/scrapinghub/scrapy-poet/pull/119#discussion_r1093194207.

~Also addresses the failing tests as mentioned in https://github.com/scrapinghub/scrapy-poet/issues/123.~  Moved into another PR: https://github.com/scrapinghub/scrapy-poet/pull/125