### PR TITLE
Fix CI failing on `min`, `asyncio`, and `asyncio-min` envs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,8 @@
 name: tox
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
+  push:
     branches: [ master ]
 
 jobs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -88,6 +88,8 @@ TBR
 
 * Documentation improvements.
 
+* Various test and CI Fixes.
+
 * Deprecations:
 
     * The ``SCRAPY_POET_OVERRIDES`` setting has been replaced by

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,10 +93,10 @@ TBR
 * Fix the ``twisted.internet.error.ReactorAlreadyInstalledError`` error raised
   when using Twisted < 21.2.0.
 
-* Fix CI configuration that doesn't follow it's intended commands in these
-  tox environments: ``min``, ``asyncio-min``, and ``asyncio``. This ensures
-  that page objects using ``asyncio`` should work properly, alongside the minimum
-  specified Twisted version.
+* Fix test configuration that doesn't follow the intended commands and dependencies
+  in these tox environments: ``min``, ``asyncio-min``, and ``asyncio``. This
+  ensures that page objects using ``asyncio`` should work properly, alongside
+  the minimum specified Twisted version.
 
 * Documentation improvements.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -86,6 +86,10 @@ TBR
   :class:`scrapy.Request <scrapy.http.Request>`'s callback is set to
   :func:`scrapy.http.request.NO_CALLBACK`.
 
+* Fix ``TypeError`` when using Twisted <= 21.7.0 since scrapy-poet was using
+  ``twisted.internet.defer.Deferred[object]`` type annotation before which was
+  not subscriptable.
+
 * Documentation improvements.
 
 * Various test and CI Fixes.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,9 +90,15 @@ TBR
   ``twisted.internet.defer.Deferred[object]`` type annotation before which was
   not subscriptable.
 
-* Documentation improvements.
+* Fix the ``twisted.internet.error.ReactorAlreadyInstalledError`` error raised
+  when using Twisted < 21.2.0.
 
-* Various test and CI Fixes.
+* Fix CI configuration that doesn't follow it's intended commands in these
+  tox environments: ``min``, ``asyncio-min``, and ``asyncio``. This ensures
+  that page objects using ``asyncio`` should work properly, alongside the minimum
+  specified Twisted version.
+
+* Documentation improvements.
 
 * Deprecations:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -91,7 +91,7 @@ TBR
   not subscriptable.
 
 * Fix the ``twisted.internet.error.ReactorAlreadyInstalledError`` error raised
-  when using Twisted < 21.2.0.
+  when using the ``scrapy savefixture`` command and Twisted < 21.2.0 is installed.
 
 * Fix test configuration that doesn't follow the intended commands and dependencies
   in these tox environments: ``min``, ``asyncio-min``, and ``asyncio``. This

--- a/scrapy_poet/commands.py
+++ b/scrapy_poet/commands.py
@@ -84,6 +84,7 @@ class SaveFixtureCommand(ScrapyCommand):
         spider_cls = spider_for(cls)
         self.settings["ITEM_PIPELINES"][SavingPipeline] = 100
         self.settings["DOWNLOADER_MIDDLEWARES"][SavingInjectionMiddleware] = 543
+        self.settings["TWISTED_REACTOR"] = "twisted.internet.epollreactor.EPollReactor"
 
         frozen_time = datetime.datetime.now(datetime.timezone.utc).replace(
             microsecond=0

--- a/scrapy_poet/commands.py
+++ b/scrapy_poet/commands.py
@@ -84,7 +84,6 @@ class SaveFixtureCommand(ScrapyCommand):
         spider_cls = spider_for(cls)
         self.settings["ITEM_PIPELINES"][SavingPipeline] = 100
         self.settings["DOWNLOADER_MIDDLEWARES"][SavingInjectionMiddleware] = 543
-        self.settings["TWISTED_REACTOR"] = "twisted.internet.epollreactor.EPollReactor"
 
         frozen_time = datetime.datetime.now(datetime.timezone.utc).replace(
             microsecond=0

--- a/scrapy_poet/downloadermiddlewares.py
+++ b/scrapy_poet/downloadermiddlewares.py
@@ -139,7 +139,8 @@ class InjectionMiddleware:
                 "dependencies in the parse() method won't be built by "
                 "scrapy-poet. However, if the request has callback=parse, "
                 "the annotated dependencies will be built.\n\n"
-                "See the Pitfalls doc for more info."
+                "See the Pitfalls doc for more info.",
+                stacklevel=2,
             )
             return response
 

--- a/scrapy_poet/downloadermiddlewares.py
+++ b/scrapy_poet/downloadermiddlewares.py
@@ -122,7 +122,7 @@ class InjectionMiddleware:
     @inlineCallbacks
     def process_response(
         self, request: Request, response: Response, spider: Spider
-    ) -> Generator[Deferred[object], object, Response]:
+    ) -> Generator[Deferred, object, Response]:
         """This method fills :attr:`scrapy.Request.cb_kwargs
         <scrapy.http.Request.cb_kwargs>` with instances for the required Page
         Objects found in the callback signature.

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -337,7 +337,7 @@ class ItemProvider(PageObjectInputProvider):
         to_provide: Set[Callable],
         request: Request,
         response: Response,
-    ) -> Generator[Deferred[object], object, List[Any]]:
+    ) -> Generator[Deferred, object, List[Any]]:
         results = []
         for cls in to_provide:
             item = self.get_from_cache(request, cls)

--- a/scrapy_poet/spidermiddlewares.py
+++ b/scrapy_poet/spidermiddlewares.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 
 from scrapy import Spider
-from scrapy.downloadermiddlewares.retry import get_retry_request
 from scrapy.http import Request, Response
 from web_poet.exceptions import Retry
 
@@ -16,6 +15,10 @@ class RetryMiddleware:
         exception: BaseException,
         spider: Spider,
     ) -> Optional[List[Request]]:
+        # Needed for Twisted < 21.2.0. See the discussion thread linked below:
+        # https://github.com/scrapinghub/scrapy-poet/pull/129#discussion_r1102693967
+        from scrapy.downloadermiddlewares.retry import get_retry_request
+
         if not isinstance(exception, Retry):
             return None
         new_request_or_none = get_retry_request(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+# To be compatible when running pytest with "--reactor=asyncio"
+if os.environ.get("REACTOR", "") == "asyncio":
+    from scrapy.utils.reactor import install_reactor
+
+    install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 import os
 
-# To be compatible when running pytest with "--reactor=asyncio"
+# Note that tox.ini should only set the REACTOR env variable when running
+# pytest with "--reactor=asyncio".
 if os.environ.get("REACTOR", "") == "asyncio":
     from scrapy.utils.reactor import install_reactor
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,6 @@ commands =
         --doctest-modules \
         {posargs:scrapy_poet tests}
 
-[testenv:asyncio]
-commands =
-    {[testenv]commands} --reactor=asyncio
-
 [pinned]
 deps =
     {[testenv]deps}
@@ -26,6 +22,13 @@ deps =
     sqlitedict==1.5.0
     url-matcher==0.2.0
     web-poet==0.7.0
+
+    # https://stackoverflow.com/a/73046084
+    Twisted==21.7.0
+    # https://github.com/scrapy/scrapy/issues/5635
+    pyopenssl==22.0.0
+    # https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1368871248
+    cryptography<39
 
 [testenv:min]
 basepython = python3.7
@@ -48,6 +51,12 @@ basepython=python3.7
 deps =
     {[pinned]deps}
     scrapy==2.8.0
+
+[testenv:asyncio]
+commands =
+    {[testenv]commands} --reactor=asyncio
+deps =
+    {[pinned]deps}
 
 [testenv:asyncio-min]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,6 @@ deps =
     url-matcher==0.2.0
     web-poet==0.7.0
 
-    # https://stackoverflow.com/a/73046084
-    Twisted==21.7.0
     # https://github.com/scrapy/scrapy/issues/5635
     pyopenssl==22.0.0
     # https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1368871248
@@ -35,6 +33,7 @@ basepython = python3.7
 deps =
     {[pinned]deps}
     scrapy==2.6.0
+    Twisted==18.9.0
 
 # Before ``scrapy.http.request.NO_CALLBACK`` was introduced.
 # See: https://github.com/scrapinghub/scrapy-poet/issues/48

--- a/tox.ini
+++ b/tox.ini
@@ -23,17 +23,17 @@ deps =
     url-matcher==0.2.0
     web-poet==0.7.0
 
-    # https://github.com/scrapy/scrapy/issues/5635
-    pyopenssl==22.0.0
-    # https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1368871248
-    cryptography<39
-
 [testenv:min]
 basepython = python3.7
 deps =
     {[pinned]deps}
     scrapy==2.6.0
     Twisted==18.9.0
+
+    # https://github.com/scrapy/scrapy/issues/5635
+    pyopenssl==22.0.0
+    # https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1368871248
+    cryptography<39
 
 # Before ``scrapy.http.request.NO_CALLBACK`` was introduced.
 # See: https://github.com/scrapinghub/scrapy-poet/issues/48

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,8 @@ deps =
     scrapy==2.8.0
 
 [testenv:asyncio]
+setenv =
+    REACTOR=asyncio
 commands =
     {[testenv]commands} --reactor=asyncio
 deps =
@@ -60,6 +62,8 @@ deps =
 
 [testenv:asyncio-min]
 basepython = python3.7
+setenv =
+    {[testenv:asyncio]setenv}
 commands =
     {[testenv:asyncio]commands}
 deps =


### PR DESCRIPTION
Built on top of #126 since it needs the `is_min_scrapy_version()` utility function.

These changes are necessary since otherwise, GitHub actions was not using some of the pinned configurations of `min`, `asyncio`, and `asyncio-min`.

For example, `min` was not using `scrapy==2.6.0` but the latest version at the current time: [https://github.com/scrapinghub/scrapy-poet/actions/runs/4047094013/jobs/6960692434](https://github.com/scrapinghub/scrapy-poet/actions/runs/4047094013/jobs/6960692434)