### PR TITLE
bump min Twisted 18.9.0 → 21.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,11 @@ TBR
 * Moved some of the utility functions from the test module into
   ``scrapy_poet.utils.testing``.
 
+* Now requires Twisted >= 21.7.0 instead of >= 18.9.0. This prevents a ``TypeError``
+  from happening since scrapy-poet uses the ``twisted.internet.defer.Deferred[object]`` 
+  type annotation in its code. On older Twisted versions, ``Deferred`` is not
+  subscriptable.
+
 * Documentation improvements.
 
 * Deprecations:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "scrapy >= 2.6.0",
         "sqlitedict >= 1.5.0",
         "time_machine",
-        "twisted >= 18.9.0",
+        "twisted >= 21.7.0",
         "url-matcher >= 0.2.0",
         "web-poet >= 0.7.0",
     ],


### PR DESCRIPTION
Avoids #128 from happening

I've tried all twisted versions from 18.9.0 and it seems 21.7.0 is the oldest one that makes `Deferred` subscriptable.

This is also compatible with our pinned dependency on #129, which uses `Twisted==21.7.0`. ([code reference](https://github.com/scrapinghub/scrapy-poet/pull/129/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R27)).