### PR TITLE
add .readthedocs.yml config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,6 @@ version: 2
 formats: all
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: true
 
 build:
   os: ubuntu-22.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ sphinx:
 build:
   os: ubuntu-22.10
   tools:
-    python: "3.7"  # Keep in sync with .github/workflows/tests-ubuntu.yml
+    python: "3.11"  # Keep in sync with .github/workflows/tests.yml
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+version: 2
+formats: all
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+build:
+  os: ubuntu-22.10
+  tools:
+    python: "3.7"  # Keep in sync with .github/workflows/tests-ubuntu.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ sphinx:
   fail_on_warning: true
 
 build:
-  os: ubuntu-22.10
+  os: ubuntu-22.04
   tools:
     python: "3.11"  # Keep in sync with .github/workflows/tests.yml
 


### PR DESCRIPTION
Fixes failing build in [https://readthedocs.org/projects/scrapy-poet/builds/19661918/](https://readthedocs.org/projects/scrapy-poet/builds/19661918/) since it's not using Python 3.7 which `async-lru` doesn't support

Related to https://github.com/scrapinghub/web-poet/pull/147