### PR TITLE
Amend scrapy open_in_browser tool.

### DIFF
--- a/docs/intro/pitfalls.rst
+++ b/docs/intro/pitfalls.rst
@@ -191,8 +191,8 @@ skip any dependency from being built because there is none:
 Similarly, the best way to completely avoid the said warning and this **scrapy-poet**
 behavior is to avoid defining a ``parse()`` method and instead choose any other name.
 
-Open in browser
----------------
+Opening a response in a web browser
+===================================
 
 When using scrapy-poet, the ``open_in_browser`` function from Scrapy may raise
 the following exception:

--- a/docs/intro/pitfalls.rst
+++ b/docs/intro/pitfalls.rst
@@ -198,11 +198,13 @@ If you encounter a `TypeError` when trying to use the `open_in_browser`
 function from Scrapy with the `scrapy_poet` library:
 
 .. code-block:: python
+
     TypeError: Unsupported response type: HttpResponse
 
 Therefore, to use the open_in_browser function in your Scrapy project with scrapy_poet,
 make sure to import it from the `scrapy_poet.utils` module using the following import statement:
 
 .. code-block:: python
+
     from scrapy_poet.utils import open_in_browser
 

--- a/docs/intro/pitfalls.rst
+++ b/docs/intro/pitfalls.rst
@@ -190,3 +190,19 @@ skip any dependency from being built because there is none:
 
 Similarly, the best way to completely avoid the said warning and this **scrapy-poet**
 behavior is to avoid defining a ``parse()`` method and instead choose any other name.
+
+Open in browser
+---------------
+
+If you encounter a `TypeError` when trying to use the `open_in_browser`
+function from Scrapy with the `scrapy_poet` library:
+
+.. code-block:: python
+    TypeError: Unsupported response type: HttpResponse
+
+Therefore, to use the open_in_browser function in your Scrapy project with scrapy_poet,
+make sure to import it from the `scrapy_poet.utils` module using the following import statement:
+
+.. code-block:: python
+    from scrapy_poet.utils import open_in_browser
+

--- a/docs/intro/pitfalls.rst
+++ b/docs/intro/pitfalls.rst
@@ -194,17 +194,16 @@ behavior is to avoid defining a ``parse()`` method and instead choose any other 
 Open in browser
 ---------------
 
-If you encounter a `TypeError` when trying to use the `open_in_browser`
-function from Scrapy with the `scrapy_poet` library:
+When using scrapy-poet, the ``open_in_browser`` function from Scrapy may raise
+the following exception:
 
 .. code-block:: python
 
     TypeError: Unsupported response type: HttpResponse
 
-Therefore, to use the open_in_browser function in your Scrapy project with scrapy_poet,
-make sure to import it from the `scrapy_poet.utils` module using the following import statement:
+To avoid that, use the ``open_in_browser`` function from ``scrapy_poet.utils``
+instead:
 
 .. code-block:: python
 
     from scrapy_poet.utils import open_in_browser
-

--- a/scrapy_poet/utils/__init__.py
+++ b/scrapy_poet/utils/__init__.py
@@ -6,8 +6,9 @@ from warnings import warn
 from packaging.version import Version
 from scrapy import __version__ as SCRAPY_VERSION
 from scrapy.crawler import Crawler
-from scrapy.http import Request, Response
+from scrapy.http import HtmlResponse, Request, Response
 from scrapy.utils.project import inside_project, project_data_dir
+from scrapy.utils.response import open_in_browser as scrapy_open_in_browser
 from web_poet import (
     HttpRequest,
     HttpResponse,
@@ -53,6 +54,27 @@ def scrapy_response_to_http_response(response: Response) -> HttpResponse:
         body=response.body,
         status=response.status,
         headers=HttpResponseHeaders.from_bytes_dict(response.headers),
+        **kwargs,
+    )
+
+
+def open_in_browser(response):
+    scrapy_open_in_browser(http_response_to_scrapy_response(response))
+
+
+def http_response_to_scrapy_response(response: HttpResponse) -> HtmlResponse:
+    """Convenience method to convert a ``web_poet.HttpResponse`` into a
+    ``scrapy.http.HtmlResponse``.
+    """
+    kwargs = {}
+    encoding = getattr(response, "_encoding", None) or "utf-8"
+    kwargs["encoding"] = encoding
+
+    return HtmlResponse(
+        url=response.url._url,
+        body=response.text,
+        status=response.status,
+        headers=response.headers,
         **kwargs,
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from scrapy_poet.utils import (
     create_registry_instance,
     get_scrapy_data_path,
     http_request_to_scrapy_request,
+    http_response_to_scrapy_response,
     scrapy_response_to_http_response,
 )
 
@@ -175,6 +176,83 @@ def test_scrapy_response_to_http_response(scrapy_response, http_response):
     assert result.status == http_response.status
     assert result.headers == http_response.headers
     assert result._encoding == http_response._encoding
+
+
+@pytest.mark.parametrize(
+    "scrapy_response,http_response",
+    (
+        (
+            Response("https://example.com"),
+            HttpResponse("https://example.com", body=b"", status=200),
+        ),
+        (
+            Response("https://example.com", body=b"a"),
+            HttpResponse("https://example.com", body=b"a", status=200),
+        ),
+        (
+            Response("https://example.com", status=429),
+            HttpResponse("https://example.com", body=b"", status=429),
+        ),
+        (
+            Response("https://example.com", headers={"a": "b"}),
+            HttpResponse(
+                "https://example.com",
+                body=b"",
+                status=200,
+                headers={"a": "b"},
+            ),
+        ),
+        (
+            Response("https://example.com", headers={"a": "b"}),
+            HttpResponse(
+                "https://example.com",
+                body=b"",
+                status=200,
+                headers=(("a", "b"),),
+            ),
+        ),
+        (
+            Response("https://example.com", headers=(("a", "b"),)),
+            HttpResponse(
+                "https://example.com",
+                body=b"",
+                status=200,
+                headers=(("a", "b"),),
+            ),
+        ),
+        pytest.param(
+            Response("https://example.com", headers=(("a", "b"), ("a", "c"))),
+            HttpResponse(
+                "https://example.com",
+                body=b"",
+                status=200,
+                headers=(("a", "b"), ("a", "c")),
+            ),
+            marks=pytest.mark.xfail(
+                reason="https://github.com/scrapy/scrapy/issues/5515",
+            ),
+        ),
+        (
+            TextResponse("https://example.com", body="a", encoding="ascii"),
+            HttpResponse(
+                "https://example.com", body=b"a", status=200, encoding="ascii"
+            ),
+        ),
+        (
+            TextResponse("https://example.com", body="a", encoding="utf-8"),
+            HttpResponse(
+                "https://example.com", body=b"a", status=200, encoding="utf-8"
+            ),
+        ),
+    ),
+)
+def test_http_response_to_scrapy_response(scrapy_response, http_response):
+    result = http_response_to_scrapy_response(http_response)
+    assert str(result.url) == str(http_response.url)
+    assert result.body == scrapy_response.body
+    assert result.status == scrapy_response.status
+    assert result.headers == scrapy_response.headers
+    assert result._encoding == getattr(scrapy_response, "_encoding", "utf-8")
 
 
 @mock.patch("scrapy_poet.utils.consume_modules")


### PR DESCRIPTION
Fixes https://github.com/scrapinghub/scrapy-poet/issues/91

The error:
```
open_in_browser(po.response)
Traceback (most recent call last):
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/_pydevd_bundle/pydevd_exec2.py", line 3, in Exec
    exec(exp, global_vars, local_vars)
  File "<input>", line 1, in <module>
  File "/Users/bulat/PycharmProjects/zyteprojects/envs/web-poet/lib/python3.10/site-packages/scrapy/utils/response.py", line 101, in open_in_browser
    raise TypeError("Unsupported response type: " f"{response.__class__.__name__}")
TypeError: Unsupported response type: HttpResponse
```