### PR TITLE
Stats

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ To get started, see :ref:`intro-install` and :ref:`intro-tutorial`.
    :maxdepth: 1
 
    rules-from-web-poet
+   stats
    providers
    testing
 

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -5,4 +5,4 @@ Stats
 =====
 
 scrapy-poet tracks :external+web-poet:ref:`web-poet stats <stats>` as part of
-:ref:`Scrapy stats <topics-stats>`, prefixed with ``scrapy-poet/stats/``.
+:ref:`Scrapy stats <topics-stats>`, prefixed with ``poet/stats/``.

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -1,0 +1,8 @@
+.. _stats:
+
+=====
+Stats
+=====
+
+scrapy-poet tracks :external+web-poet:ref:`web-poet stats <stats>` as part of
+:ref:`Scrapy stats <topics-stats>`, prefixed with ``scrapy-poet/stats/``.

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -29,7 +29,7 @@ from web_poet import (
     ResponseUrl,
     Stats,
 )
-from web_poet.page_inputs.stats import StatCollector
+from web_poet.page_inputs.stats import StatCollector, StatNum
 from web_poet.pages import is_injectable
 
 from scrapy_poet.downloader import create_scrapy_downloader
@@ -345,7 +345,7 @@ class CrawlerStatCollector(StatCollector):
     def set(self, key: str, value: Any) -> None:  # noqa: D102
         self._stats.set_value(f"{self._prefix}{key}", value)
 
-    def inc(self, key: str, value: int = 1) -> None:  # noqa: D102
+    def inc(self, key: str, value: StatNum = 1) -> None:  # noqa: D102
         self._stats.inc_value(f"{self._prefix}{key}", value)
 
 

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -340,12 +340,13 @@ class ItemProvider(PageObjectInputProvider):
 class CrawlerStatCollector(StatCollector):
     def __init__(self, stats):
         self._stats = stats
+        self._prefix = "scrapy-poet/stats/"
 
     def set(self, key: str, value: Any) -> None:  # noqa: D102
-        self._stats.set_value(key, value)
+        self._stats.set_value(f"{self._prefix}{key}", value)
 
     def inc(self, key: str, value: int = 1) -> None:  # noqa: D102
-        self._stats.inc_value(key, value)
+        self._stats.inc_value(f"{self._prefix}{key}", value)
 
 
 class StatsProvider(PageObjectInputProvider):

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -29,6 +29,7 @@ from web_poet import (
     ResponseUrl,
     Stats,
 )
+from web_poet.page_inputs.stats import StatCollector
 from web_poet.pages import is_injectable
 
 from scrapy_poet.downloader import create_scrapy_downloader
@@ -336,7 +337,7 @@ class ItemProvider(PageObjectInputProvider):
         return results
 
 
-class StatCollector:
+class CrawlerStatCollector(StatCollector):
     def __init__(self, stats):
         self._stats = stats
 
@@ -360,4 +361,4 @@ class StatsProvider(PageObjectInputProvider):
         stat collector.
         """
 
-        return [Stats(stat_collector=StatCollector(crawler.stats))]
+        return [Stats(stat_collector=CrawlerStatCollector(crawler.stats))]

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -337,7 +337,7 @@ class ItemProvider(PageObjectInputProvider):
         return results
 
 
-class CrawlerStatCollector(StatCollector):
+class ScrapyPoetStatCollector(StatCollector):
     def __init__(self, stats):
         self._stats = stats
         self._prefix = "scrapy-poet/stats/"
@@ -362,4 +362,4 @@ class StatsProvider(PageObjectInputProvider):
         stat collector.
         """
 
-        return [Stats(stat_collector=CrawlerStatCollector(crawler.stats))]
+        return [Stats(stat_collector=ScrapyPoetStatCollector(crawler.stats))]

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -27,6 +27,7 @@ from web_poet import (
     PageParams,
     RequestUrl,
     ResponseUrl,
+    Stats,
 )
 from web_poet.pages import is_injectable
 
@@ -333,3 +334,30 @@ class ItemProvider(PageObjectInputProvider):
 
             results.append(item)
         return results
+
+
+class StatCollector:
+    def __init__(self, stats):
+        self._stats = stats
+
+    def set(self, key: str, value: Any) -> None:  # noqa: D102
+        self._stats.set_value(key, value)
+
+    def inc(self, key: str, value: int = 1) -> None:  # noqa: D102
+        self._stats.inc_value(key, value)
+
+
+class StatsProvider(PageObjectInputProvider):
+    """This class provides :class:`web_poet.Stats
+    <web_poet.page_inputs.client.Stats>` instances.
+    """
+
+    provided_classes = {Stats}
+
+    def __call__(self, to_provide: Set[Callable], crawler: Crawler):
+        """Creates an :class:`web_poet.Stats
+        <web_poet.page_inputs.client.Stats>` instance using Scrapy's
+        stat collector.
+        """
+
+        return [Stats(stat_collector=StatCollector(crawler.stats))]

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -340,7 +340,7 @@ class ItemProvider(PageObjectInputProvider):
 class ScrapyPoetStatCollector(StatCollector):
     def __init__(self, stats):
         self._stats = stats
-        self._prefix = "scrapy-poet/stats/"
+        self._prefix = "poet/stats/"
 
     def set(self, key: str, value: Any) -> None:  # noqa: D102
         self._stats.set_value(f"{self._prefix}{key}", value)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "time_machine",
         "twisted >= 18.9.0",
         "url-matcher >= 0.2.0",
-        "web-poet >= 0.12.0",
+        "web-poet @ git+https://github.com/Gallaecio/web-poet.git@stats",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "time_machine",
         "twisted >= 18.9.0",
         "url-matcher >= 0.2.0",
-        "web-poet @ git+https://github.com/Gallaecio/web-poet.git@stats",
+        "web-poet >= 0.15",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -272,4 +272,6 @@ def test_stats_provider(settings):
     stats.inc("b", 5)
     stats.inc("c")
 
-    assert crawler.stats._stats == {"a": "1", "b": 8, "c": 1}
+    expected = {"a": "1", "b": 8, "c": 1}
+    actual = {k: v for k, v in crawler.stats._stats.items() if k in expected}
+    assert actual == expected

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -18,6 +18,7 @@ from scrapy_poet.page_input_providers import (
     ItemProvider,
     PageObjectInputProvider,
     PageParamsProvider,
+    StatsProvider,
 )
 from scrapy_poet.utils.mockserver import get_ephemeral_port
 from scrapy_poet.utils.testing import (
@@ -253,3 +254,22 @@ def test_item_provider_cache(settings):
     # garbage collected.
     inside()
     assert len(provider._cached_instances) == 0
+
+
+def test_stats_provider(settings):
+    crawler = get_crawler(Spider, settings)
+    injector = Injector(crawler)
+    provider = StatsProvider(injector)
+
+    results = provider(set(), crawler)
+
+    stats = results[0]
+    assert stats._stats._stats == crawler.stats
+
+    stats.set("a", "1")
+    stats.set("b", 2)
+    stats.inc("b")
+    stats.inc("b", 5)
+    stats.inc("c")
+
+    assert stats._stats._stats._stats == {"a": "1", "b": 8, "c": 1}

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -273,5 +273,6 @@ def test_stats_provider(settings):
     stats.inc("c")
 
     expected = {"a": "1", "b": 8, "c": 1}
+    expected = {f"scrapy-poet/stats/{k}": v for k, v in expected.items()}
     actual = {k: v for k, v in crawler.stats._stats.items() if k in expected}
     assert actual == expected

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -273,6 +273,6 @@ def test_stats_provider(settings):
     stats.inc("c")
 
     expected = {"a": "1", "b": 8, "c": 1}
-    expected = {f"scrapy-poet/stats/{k}": v for k, v in expected.items()}
+    expected = {f"poet/stats/{k}": v for k, v in expected.items()}
     actual = {k: v for k, v in crawler.stats._stats.items() if k in expected}
     assert actual == expected

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -272,4 +272,4 @@ def test_stats_provider(settings):
     stats.inc("b", 5)
     stats.inc("c")
 
-    assert stats._stats._stats._stats == {"a": "1", "b": 8, "c": 1}
+    assert crawler.stats._stats == {"a": "1", "b": 8, "c": 1}

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ changedir = docs
 deps =
     -rdocs/requirements.txt
 commands =
-    sphinx-build -b html . {envtmpdir}/html  # TODO: Restore -W before merging
+    sphinx-build -W -b html . {envtmpdir}/html
 
 [testenv:linters]
 deps = -rrequirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ changedir = docs
 deps =
     -rdocs/requirements.txt
 commands =
-    sphinx-build -W -b html . {envtmpdir}/html
+    sphinx-build -b html . {envtmpdir}/html  # TODO: Restore -W before merging
 
 [testenv:linters]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Follow-up to https://github.com/scrapinghub/web-poet/pull/175.

I wonder if we should include some prefix on stats, like `scrapy_poet/`, `scrapy_poet/<page object import path>/`, or , `scrapy_poet/<page object import path>/stats/`.