### PR TITLE
Handle item overrides

### DIFF
--- a/scrapy_poet/commands.py
+++ b/scrapy_poet/commands.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 from pathlib import Path
-from typing import Optional, Type
+from typing import Dict, Optional, Type
 
 import andi
 import scrapy
@@ -34,10 +34,14 @@ frozen_time = None
 class SavingInjector(Injector):
     @inlineCallbacks
     def build_instances_from_providers(
-        self, request: Request, response: Response, plan: andi.Plan
+        self,
+        request: Request,
+        response: Response,
+        plan: andi.Plan,
+        prev_instances: Optional[Dict] = None,
     ):
         instances = yield super().build_instances_from_providers(
-            request, response, plan
+            request, response, plan, prev_instances
         )
         if request.meta.get("savefixture", False):
             saved_dependencies.extend(instances.values())

--- a/scrapy_poet/downloadermiddlewares.py
+++ b/scrapy_poet/downloadermiddlewares.py
@@ -34,7 +34,7 @@ DEFAULT_PROVIDERS = {
     PageParamsProvider: 700,
     RequestUrlProvider: 800,
     ResponseUrlProvider: 900,
-    ItemProvider: 1000,
+    ItemProvider: 2000,
 }
 
 InjectionMiddlewareTV = TypeVar("InjectionMiddlewareTV", bound="InjectionMiddleware")

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -441,6 +441,7 @@ def get_injector_for_testing(
     spider = MySpider()
     spider.settings = settings
     crawler.spider = spider
+    crawler.stats = load_object(crawler.settings["STATS_CLASS"])(crawler)
     if not registry:
         registry = create_registry_instance(RulesRegistry, crawler)
     return Injector(crawler, registry=registry)

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -203,6 +203,14 @@ class Injector:
             if not provided_classes:
                 continue
 
+            # If dependency instances were already made by previously invoked
+            # providers, don't try to build them again since it may result in
+            # incorrect values (e.g. PO modifying an item > 2 times).
+            required_deps = set(plan.dependencies[-1][1].values())
+            built_deps = set(instances.keys())
+            if required_deps and required_deps == built_deps:
+                continue
+
             objs, fingerprint = [], None
             cache_hit = False
             if self.cache:

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -106,6 +106,10 @@ class PageObjectInputProvider:
     provided_classes: Union[Set[Callable], Callable[[Callable], bool]]
     name: ClassVar[str] = ""  # It must be a unique name. Used by the cache mechanism
 
+    # If set to True, the Injector will not skip the Provider when the dependency has
+    # been built. Instead, the Injector will pass the previously built instances (by
+    # the other providers) to the Provider. The Provider can then choose to modify
+    # these previous instances before returning them to the Injector.
     allow_prev_instances: bool = False
 
     def is_provided(self, type_: Callable) -> bool:

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -310,50 +310,34 @@ class ItemProvider(PageObjectInputProvider):
                 externally_provided=self.injector.is_class_provided_by_any_provider,
             )
 
-            # If dependencies are already built for the PO, we can build it here.
-            # Avoid calling build_instances() since it may result in deadlocks.
-            po_deps = [cls for cls, kwargs_spec in plan.dependencies][:-1]
-            if prev_instances.keys() == set(po_deps):
-                _, kwargs_spec = plan.dependencies[-1]
-                po_instances = {
-                    page_object_cls: page_object_cls(
-                        **kwargs_spec.kwargs(prev_instances)
+            try:
+                deferred_or_future = maybe_deferred_to_future(
+                    self.injector.build_instances(
+                        request, response, plan, prev_instances
                     )
-                }
+                )
+                # RecursionError NOT raised when ``AsyncioSelectorReactor`` is used.
+                # Could be related: https://github.com/python/cpython/issues/93837
 
-            else:
-                try:
-                    deferred_or_future = maybe_deferred_to_future(
-                        self.injector.build_instances(
-                            request, response, plan, prev_instances
+                # Need to check before awaiting on the ``asyncio.Future``
+                # before it gets stuck on a potential deadlock.
+                if asyncio.isfuture(deferred_or_future):
+                    if self.check_if_deadlock(request):
+                        raise ProviderDependencyDeadlockError(
+                            self.template_deadlock_msg.format(plan=plan)
                         )
-                    )
-                    # RecursionError NOT raised when ``AsyncioSelectorReactor`` is used.
-                    # Could be related: https://github.com/python/cpython/issues/93837
 
-                    # Need to check before awaiting on the ``asyncio.Future``
-                    # before it gets stuck on a potential deadlock.
-                    if asyncio.isfuture(deferred_or_future):
-                        if self.check_if_deadlock(request):
-                            raise ProviderDependencyDeadlockError(
-                                self.template_deadlock_msg.format(plan=plan)
-                            )
+                po_instances = await deferred_or_future
+            except RecursionError:
+                raise ProviderDependencyDeadlockError(
+                    self.template_deadlock_msg.format(plan=plan)
+                )
 
-                    po_instances = await deferred_or_future
-                except RecursionError:
-                    raise ProviderDependencyDeadlockError(
-                        self.template_deadlock_msg.format(plan=plan)
-                    )
+            page_object = po_instances[page_object_cls]
+            item = await page_object.to_item()
 
-            # See if the recursive calls produced an item and put it in the cache.
-            # Otherwise, ``to_item()`` will be called multiple times which can
-            # lead to bad values in some fields.
-            if not (item := self.get_from_cache(request, cls)):
-                page_object = po_instances[page_object_cls]
-                item = await page_object.to_item()
-
-                self.update_cache(request, po_instances)
-                self.update_cache(request, {type(item): item})
+            self.update_cache(request, po_instances)
+            self.update_cache(request, {type(item): item})
 
             results.append(item)
         return results

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -284,7 +284,7 @@ class ItemProvider(PageObjectInputProvider):
         to_provide: Set[Callable],
         request: Request,
         response: Response,
-        prev_instances: Any,
+        prev_instances: Dict,
     ) -> List[Any]:
         results = []
         for cls in to_provide:

--- a/scrapy_poet/page_input_providers.py
+++ b/scrapy_poet/page_input_providers.py
@@ -10,7 +10,7 @@ for example, from scrapy-playwright or from an API for automatic extraction.
 """
 import asyncio
 from dataclasses import make_dataclass
-from inspect import isclass, signature
+from inspect import isclass
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Set, Type, Union
 from warnings import warn
 from weakref import WeakKeyDictionary

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "parsel >= 1.5.0",
         "scrapy >= 2.6.0",
         "sqlitedict >= 1.5.0",
-        "time_machine",
+        "time_machine >= 2.2.0",
         "twisted >= 18.9.0",
         "url-matcher >= 0.2.0",
         "web-poet >= 0.15",

--- a/tests/test_response_required_logic.py
+++ b/tests/test_response_required_logic.py
@@ -8,6 +8,7 @@ from pytest_twisted import inlineCallbacks
 from scrapy.crawler import Crawler
 from scrapy.http import HtmlResponse, Request, TextResponse
 from scrapy.settings import Settings
+from scrapy.utils.misc import load_object
 from web_poet import ItemPage, WebPage
 
 from scrapy_poet import DummyResponse, callback_for
@@ -32,18 +33,15 @@ except ImportError:
 
 @attr.s(auto_attribs=True)
 class DummyProductResponse:
-
     data: Dict[str, Any]
 
 
 @attr.s(auto_attribs=True)
 class FakeProductResponse:
-
     data: Dict[str, Any]
 
 
 class DummyProductProvider(PageObjectInputProvider):
-
     provided_classes = {DummyProductResponse}
 
     def __call__(self, to_provide, request: scrapy.Request):
@@ -57,7 +55,6 @@ class DummyProductProvider(PageObjectInputProvider):
 
 
 class FakeProductProvider(PageObjectInputProvider):
-
     provided_classes = {FakeProductResponse}
 
     def __call__(self, to_provide):
@@ -71,7 +68,6 @@ class FakeProductProvider(PageObjectInputProvider):
 
 
 class TextProductProvider(HttpResponseProvider):
-
     # This is wrong. You should not annotate provider dependencies with classes
     # like TextResponse or HtmlResponse, you should use Response instead.
     def __call__(self, to_provide, response: TextResponse):
@@ -85,7 +81,6 @@ class StringProductProvider(HttpResponseProvider):
 
 @attr.s(auto_attribs=True)
 class DummyProductPage(ItemPage):
-
     response: DummyProductResponse
 
     @property
@@ -99,7 +94,6 @@ class DummyProductPage(ItemPage):
 
 @attr.s(auto_attribs=True)
 class FakeProductPage(ItemPage):
-
     response: FakeProductResponse
 
     @property
@@ -117,7 +111,6 @@ class BookPage(WebPage):
 
 
 class MySpider(scrapy.Spider):
-
     name = "foo"
     custom_settings = {
         "SCRAPY_POET_PROVIDERS": {
@@ -360,6 +353,7 @@ def test_is_response_going_to_be_used():
     crawler = Crawler(MySpider)
     spider = MySpider()
     crawler.spider = spider
+    crawler.stats = load_object(crawler.settings["STATS_CLASS"])(crawler)
 
     def response(request):
         return HtmlResponse(request.url, request=request, body=b"<html></html>")

--- a/tests/test_web_poet_rules.py
+++ b/tests/test_web_poet_rules.py
@@ -10,7 +10,7 @@ import os
 import socket
 import warnings
 from collections import defaultdict
-from typing import Any, Dict, List, Tuple, Type, Set, Callable, Optional
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type
 
 import attrs
 import pytest

--- a/tests/test_web_poet_rules.py
+++ b/tests/test_web_poet_rules.py
@@ -1520,16 +1520,15 @@ def test_page_object_returning_item_which_is_also_a_dep() -> None:
     settings = {
         "SCRAPY_POET_PROVIDERS": {**DEFAULT_PROVIDERS, **{MobiusProvider: 1000}}
     }
-
     # item from 'to_return'
     item, deps = yield crawl_item_and_deps(Mobius, override_settings=settings)
     assert item == Mobius(name="(modified) mobius from MobiusProvider")
     assert_deps(deps, {"item": Mobius})
 
     # calling the actual page objects should still work
-    # item, deps = yield crawl_item_and_deps(MobiusPage)
-    # assert item == Mobius(name="(modified) mobius from MobiusProvider")
-    # assert_deps(deps, {"item": Mobius})
+    item, deps = yield crawl_item_and_deps(MobiusPage, override_settings=settings)
+    assert item == Mobius(name="(modified) mobius from MobiusProvider")
+    assert_deps(deps, {"page": MobiusPage})
 
 
 # TODO: USE CASE: ProductItem as a dependency of ProductPage. ProductPage

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,9 @@ deps =
     attrs==21.3.0
     parsel==1.5.0
     sqlitedict==1.5.0
+    time_machine==1.0.0
     url-matcher==0.2.0
-    web-poet==0.7.0
+    web-poet==0.15.0
 
 [testenv:min]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,9 @@ deps =
     url-matcher==0.2.0
     web-poet==0.15.0
 
+    # https://github.com/john-kurkowski/tldextract/issues/305
+    tldextract<3.6
+
 [testenv:min]
 basepython = python3.8
 deps =
@@ -36,8 +39,6 @@ deps =
     pyopenssl==22.0.0
     # https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1368871248
     cryptography<39
-    # https://github.com/john-kurkowski/tldextract/issues/305
-    tldextract<3.6
 
 # Before ``scrapy.http.request.NO_CALLBACK`` was introduced.
 # See: https://github.com/scrapinghub/scrapy-poet/issues/48

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     attrs==21.3.0
     parsel==1.5.0
     sqlitedict==1.5.0
-    time_machine==1.0.0
+    time_machine==2.2.0
     url-matcher==0.2.0
     web-poet==0.15.0
 


### PR DESCRIPTION
Fixes the case when the following code below results in a `ProviderDependencyDeadlockError`. In this example, the issue stems from the `product: Product` dependency that's declared. However, **scrapy-poet** sees `ProductPage` as the one that provides it which causes the deadlock error.

```python
import attrs
from zyte_common_items import Product
from web_poet import handle_urls, WebPage

@handle_urls("example.com")
@attrs.define 
class ProductPage(WebPage[Product]):
    product: Product

    def name(self) -> str:
        return f"(modified) {self.product.name}"
```

The use case for this is when items like `Product` are produced by a provider and not a page object. For example, **scrapy-zyte-api**'s `ZyteApiProvider` ([reference](https://github.com/scrapy-plugins/scrapy-zyte-api/blob/main/scrapy_zyte_api/providers.py#L27-L39)). The `ProductPage` in this scenario tries to override the item produced by `ZyteApiProvider`.

---

**TODO:**

- [x] add more test cases to handle different scenarios
- [x] verify if this is the best implementation to go