### PR TITLE
enable StatsProvider by default

### DIFF
--- a/scrapy_poet/downloadermiddlewares.py
+++ b/scrapy_poet/downloadermiddlewares.py
@@ -22,6 +22,7 @@ from .page_input_providers import (
     PageParamsProvider,
     RequestUrlProvider,
     ResponseUrlProvider,
+    StatsProvider,
 )
 from .utils import create_registry_instance, is_min_scrapy_version
 
@@ -34,6 +35,7 @@ DEFAULT_PROVIDERS = {
     PageParamsProvider: 700,
     RequestUrlProvider: 800,
     ResponseUrlProvider: 900,
+    StatsProvider: 1000,
     ItemProvider: 2000,
 }
 


### PR DESCRIPTION
Taras noticed that this is isn't enabled by default.
