### PR TITLE
create a weak_cache in Injector

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -127,6 +127,14 @@ which Scrapy has. Although they are quite similar in its intended purpose,
 could be anything that could stretch beyond Scrapy's ``Responses`` `(e.g. Network
 Database queries, API Calls, AWS S3 files, etc)`.
 
+.. note::
+
+   The :class:`scrapy_poet.injection.Injector` maintains a ``.weak_cache`` which
+   stores the instances created by the providers as long as the corresponding
+   :class:`scrapy.Request <scrapy.http.Request>` instance exists. This means that
+   the instances created by earlier providers can be accessed and reused by latter
+   providers. This is turned on by default and the instances are stored in memory.
+
 
 Configuring providers
 =====================

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -203,6 +203,7 @@ class TestInjector:
             ClsReqResponse: ClsReqResponse(),
             ClsNoProviderRequired: ClsNoProviderRequired(),
         }
+        assert injector.weak_cache.get(request).keys() == {ClsReqResponse, Cls1, Cls2}
 
         instances = yield from injector.build_instances_from_providers(
             request, response, plan
@@ -212,6 +213,7 @@ class TestInjector:
             Cls2: Cls2(),
             ClsReqResponse: ClsReqResponse(),
         }
+        assert injector.weak_cache.get(request).keys() == {ClsReqResponse, Cls1, Cls2}
 
     @inlineCallbacks
     def test_build_instances_from_providers_unexpected_return(self):
@@ -230,6 +232,7 @@ class TestInjector:
             yield from injector.build_instances_from_providers(
                 response.request, response, plan
             )
+        assert injector.weak_cache.get(response.request) is None
 
         assert "Provider" in str(exinf.value)
         assert "Cls2" in str(exinf.value)
@@ -256,6 +259,7 @@ class TestInjector:
         instances = yield from injector.build_instances_from_providers(
             response.request, response, plan
         )
+        assert injector.weak_cache.get(response.request).keys() == {str}
 
         assert instances[str] == min(str_list)
 
@@ -628,6 +632,7 @@ class TestInjectorStats:
             if name.startswith(prefix)
         }
         assert set(poet_stats) == expected
+        assert injector.weak_cache.get(response.request) is None
 
     @inlineCallbacks
     def test_po_provided_via_item(self):
@@ -642,6 +647,7 @@ class TestInjectorStats:
         _ = yield from injector.build_callback_dependencies(response.request, response)
         key = "poet/injector/tests.test_injection.TestItemPage"
         assert key in set(injector.crawler.stats.get_stats())
+        assert injector.weak_cache.get(response.request) is None
 
 
 class TestInjectorOverrides:
@@ -787,6 +793,7 @@ def test_cache(tmp_path, cache_errors):
         response.request, response, plan
     )
     assert cache.exists()
+    assert injector.weak_cache.get(response.request).keys() == {Price, Name}
 
     validate_instances(instances)
 
@@ -799,6 +806,7 @@ def test_cache(tmp_path, cache_errors):
         instances = yield from injector.build_instances_from_providers(
             response.request, response, plan
         )
+    assert injector.weak_cache.get(response.request) is None
 
     # Different providers. They return a different result, but the cache data should prevail.
     providers = {
@@ -812,6 +820,7 @@ def test_cache(tmp_path, cache_errors):
     instances = yield from injector.build_instances_from_providers(
         response.request, response, plan
     )
+    assert injector.weak_cache.get(response.request).keys() == {Price, Name}
 
     validate_instances(instances)
 
@@ -823,3 +832,4 @@ def test_cache(tmp_path, cache_errors):
         instances = yield from injector.build_instances_from_providers(
             response.request, response, plan
         )
+    assert injector.weak_cache.get(response.request) is None


### PR DESCRIPTION
Currently, `SCRAPY_POET_CACHE` can be set to `True` to allow scrapy-poet to save instances created by providers locally. By default, this is turned off.

I'm proposing to introduce an `Injector.weak_cache` that would have its instances stored in memory and be removed when the corresponding `Request` instance is no longer available. By default, this is turned on. The motivation for this is to allow sharing of instances between providers by default without the risk of accumulating large number of instances locally which can result in running out of disk space.

This also means that the weakref cache mechanism in **ZyteApiProvider** ([code ref](https://github.com/scrapy-plugins/scrapy-zyte-api/blob/main/scrapy_zyte_api/providers.py#L48)) can be removed as it can use this new `.weak_cache` directly from the Injector.

Other related PRs:
- https://github.com/scrapinghub/web-poet/pull/195
- https://github.com/scrapy-plugins/scrapy-zyte-api/pull/161
- https://github.com/zytedata/zyte-spider-templates/pull/28