### PR TITLE
Enable HttpRequestProvider by default

### DIFF
--- a/scrapy_poet/downloadermiddlewares.py
+++ b/scrapy_poet/downloadermiddlewares.py
@@ -18,6 +18,7 @@ from .api import DummyResponse
 from .injection import Injector
 from .page_input_providers import (
     HttpClientProvider,
+    HttpRequestProvider,
     HttpResponseProvider,
     PageParamsProvider,
     RequestUrlProvider,
@@ -39,6 +40,7 @@ class DownloaderStatsMiddleware(DownloaderStats):
 
 
 DEFAULT_PROVIDERS = {
+    HttpRequestProvider: 400,
     HttpResponseProvider: 500,
     HttpClientProvider: 600,
     PageParamsProvider: 700,

--- a/tests/test_page_input_providers.py
+++ b/tests/test_page_input_providers.py
@@ -1,6 +1,7 @@
 import pytest
 
-from scrapy_poet import PageObjectInputProvider
+from scrapy_poet import PageObjectInputProvider, page_input_providers
+from scrapy_poet.downloadermiddlewares import DEFAULT_PROVIDERS
 from scrapy_poet.injection_errors import MalformedProvidedClassesError
 
 
@@ -38,3 +39,19 @@ class TestProvider:
         assert provider.is_provided(str)
         assert provider.is_provided(int)
         assert not provider.is_provided(float)
+
+
+def test_default_providers():
+    providers = {
+        obj
+        for obj_name, obj in page_input_providers.__dict__.items()
+        if (
+            obj_name.endswith("Provider")
+            and obj_name
+            not in {
+                "ItemProvider",  # Deprecated
+                "PageObjectInputProvider",  # Base class
+            }
+        )
+    }
+    assert providers == set(DEFAULT_PROVIDERS)


### PR DESCRIPTION
@fcanobrash found out it was not working.

Workaround for earlier versions (it was added in 0.17.0):

```python
# settings.py

from scrapy_poet.page_input_providers import HttpRequestProvider

SCRAPY_POET_PROVIDERS = {
    HttpRequestProvider: 400,
}
```