### PR TITLE
Restore and improve the annotated dynamic deps support.

### DIFF
--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -247,7 +247,7 @@ class Injector:
         """
         ns: Dict[str, type] = {}
         for type_ in dynamic_types:
-            type_ = strip_annotated(type_)
+            type_ = cast(type, strip_annotated(type_))
             if not isinstance(type_, type):
                 raise TypeError(f"Expected a dynamic dependency type, got {type_!r}")
             ns[type_.__name__] = type_

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -224,7 +224,7 @@ class Injector:
         # https://github.com/python/cpython/blob/v3.11.9/Lib/dataclasses.py#L413
         args = [f"{name}_arg: {name}" for name in type_names]
         args_str = ", ".join(args)
-        result_args = [f"{name}: {name}_arg" for name in type_names]
+        result_args = [f"strip_annotated({name}): {name}_arg" for name in type_names]
         result_args_str = ", ".join(result_args)
         create_args_str = ", ".join(type_names)
         return (

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -247,7 +247,8 @@ class Injector:
         """
         ns: Dict[str, type] = {}
         for type_ in dynamic_types:
-            if not isinstance(strip_annotated(type_), type):
+            type_ = strip_annotated(type_)
+            if not isinstance(type_, type):
                 raise TypeError(f"Expected a dynamic dependency type, got {type_!r}")
             ns[type_.__name__] = type_
         txt = Injector._get_dynamic_deps_factory_text(ns.keys())

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -20,7 +20,7 @@ from typing import (
 from weakref import WeakKeyDictionary
 
 import andi
-from andi.typeutils import issubclass_safe
+from andi.typeutils import issubclass_safe, strip_annotated
 from scrapy import Request, Spider
 from scrapy.crawler import Crawler
 from scrapy.http import Response
@@ -247,7 +247,7 @@ class Injector:
         """
         ns: Dict[str, type] = {}
         for type_ in dynamic_types:
-            if not isinstance(type_, type):
+            if not isinstance(strip_annotated(type_), type):
                 raise TypeError(f"Expected a dynamic dependency type, got {type_!r}")
             ns[type_.__name__] = type_
         txt = Injector._get_dynamic_deps_factory_text(ns.keys())

--- a/scrapy_poet/injection.py
+++ b/scrapy_poet/injection.py
@@ -245,13 +245,14 @@ class Injector:
         corresponding args. It has correct type hints so that it can be used as
         an ``andi`` custom builder.
         """
-        ns: Dict[str, type] = {}
+        type_names: List[str] = []
         for type_ in dynamic_types:
             type_ = cast(type, strip_annotated(type_))
             if not isinstance(type_, type):
                 raise TypeError(f"Expected a dynamic dependency type, got {type_!r}")
-            ns[type_.__name__] = type_
-        txt = Injector._get_dynamic_deps_factory_text(ns.keys())
+            type_names.append(type_.__name__)
+        txt = Injector._get_dynamic_deps_factory_text(type_names)
+        ns: Dict[str, Any] = {}
         exec(txt, globals(), ns)
         return ns["__create_fn__"](*dynamic_types)
 

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -989,6 +989,23 @@ def test_dynamic_deps_factory():
     assert dd == {int: 42, Cls1: c}
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="No Annotated support in Python < 3.9"
+)
+def test_dynamic_deps_factory_annotated():
+    from typing import Annotated
+
+    fn = Injector._get_dynamic_deps_factory([Annotated[Cls1, 42]])
+    args = andi.inspect(fn)
+    # the arg name needs to be fixed separately
+    assert args == {
+        "Annotated_arg": [Annotated[Cls1, 42]],
+    }
+    c1 = Cls1()
+    dd = fn(Annotated_arg=c1)
+    assert dd == {Annotated[Cls1, 42]: c1}
+
+
 def test_dynamic_deps_factory_bad_input():
     with pytest.raises(
         TypeError,

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -680,16 +680,12 @@ class TestInjector:
         injector = get_injector_for_testing({provider: 1})
 
         expected_instances = {
-            DynamicDeps: DynamicDeps(
-                {Annotated[Cls1, 42]: Cls1(), Annotated[Cls2, "foo"]: Cls2()}
-            ),
+            DynamicDeps: DynamicDeps({Cls1: Cls1(), Cls2: Cls2()}),
             Annotated[Cls1, 42]: Cls1(),
             Annotated[Cls2, "foo"]: Cls2(),
         }
         expected_kwargs = {
-            "dd": DynamicDeps(
-                {Annotated[Cls1, 42]: Cls1(), Annotated[Cls2, "foo"]: Cls2()}
-            ),
+            "dd": DynamicDeps({Cls1: Cls1(), Cls2: Cls2()}),
         }
         yield self._assert_instances(
             injector,

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -995,15 +995,18 @@ def test_dynamic_deps_factory():
 def test_dynamic_deps_factory_annotated():
     from typing import Annotated
 
-    fn = Injector._get_dynamic_deps_factory([Annotated[Cls1, 42]])
+    fn = Injector._get_dynamic_deps_factory(
+        [Annotated[Cls1, 42], Annotated[Cls2, "foo"]]
+    )
     args = andi.inspect(fn)
-    # the arg name needs to be fixed separately
     assert args == {
-        "Annotated_arg": [Annotated[Cls1, 42]],
+        "Cls1_arg": [Annotated[Cls1, 42]],
+        "Cls2_arg": [Annotated[Cls2, "foo"]],
     }
     c1 = Cls1()
-    dd = fn(Annotated_arg=c1)
-    assert dd == {Annotated[Cls1, 42]: c1}
+    c2 = Cls2()
+    dd = fn(Cls1_arg=c1, Cls2_arg=c2)
+    assert dd == {Annotated[Cls1, 42]: c1, Annotated[Cls2, "foo"]: c2}
 
 
 def test_dynamic_deps_factory_bad_input():

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1001,7 +1001,7 @@ def test_dynamic_deps_factory_text():
         txt
         == """def __create_fn__(int, Cls1):
  def dynamic_deps_factory(int_arg: int, Cls1_arg: Cls1) -> DynamicDeps:
-  return DynamicDeps({int: int_arg, Cls1: Cls1_arg})
+  return DynamicDeps({strip_annotated(int): int_arg, strip_annotated(Cls1): Cls1_arg})
  return dynamic_deps_factory"""
     )
 
@@ -1035,7 +1035,7 @@ def test_dynamic_deps_factory_annotated():
     c1 = Cls1()
     c2 = Cls2()
     dd = fn(Cls1_arg=c1, Cls2_arg=c2)
-    assert dd == {Annotated[Cls1, 42]: c1, Annotated[Cls2, "foo"]: c2}
+    assert dd == {Cls1: c1, Cls2: c2}
 
 
 def test_dynamic_deps_factory_bad_input():


### PR DESCRIPTION
A quick fix for a regression in #207 that raised an exception for annotated types.

The proper annotated dynamic deps support including support for multiple annotated deps requires some refactoring and logic changes and will be done separately.

Edit: as the most basic fix doesn't work on 3.9 I added a better one that includes support for multiple annotated deps but not other things that are still needed.

Edit 2: here is hopefully the complete fix, with making the results not annotated.