### PR TITLE
Fix CI (pin older Scrapy).

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ deps =
     {[testenv]deps}
     andi==0.6.0
     attrs==21.3.0
+    # pin older cssselect for old parsel
+    cssselect==1.2.0
     parsel==1.5.0
     sqlitedict==1.5.0
     time_machine==2.7.1

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest-cov
     pytest-twisted
     Twisted
-
+    Scrapy < 2.13.0
 commands =
     py.test \
         --cov-report=term --cov-report=html --cov-report= --cov-report=xml --cov=scrapy_poet \
@@ -97,8 +97,8 @@ commands = pre-commit run --all-files --show-diff-on-failure
 [testenv:twinecheck]
 basepython = python3
 deps =
-    twine==5.1.1
-    build==1.2.2
+    twine==6.1.0
+    build==1.2.2.post1
 commands =
     python -m build --sdist
     twine check dist/*


### PR DESCRIPTION
Some tests hang with new Scrapy due to https://github.com/scrapy/scrapy/issues/6784