### PR TITLE
Fix the trusted publishing env name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/Scrapy
+      url: https://pypi.org/p/scrapy-poet
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
The old one worked because the PyPI setup didn't specify one.