### PR TITLE
Add __version__ attribute

### DIFF
--- a/scrapy_poet/__init__.py
+++ b/scrapy_poet/__init__.py
@@ -1,3 +1,8 @@
+from importlib.metadata import version
+
+__version__ = version("scrapy-poet")
+
+
 from .api import DummyResponse, callback_for
 from .downloadermiddlewares import DownloaderStatsMiddleware, InjectionMiddleware
 from .injection import DynamicDeps


### PR DESCRIPTION
I recently had issues in an agent session because it was trying to identify the version with `python -c "import scrapy_poet; print(scrapy_poet.__version__)"`